### PR TITLE
Integrate CC comments

### DIFF
--- a/appendix_abstractions.asciidoc
+++ b/appendix_abstractions.asciidoc
@@ -213,7 +213,7 @@ def test_when_a_file_has_been_renamed_in_the_source():
 ====
 
 Wowsers, that's a lot of setup for two very simple cases! The problem is that
-our domain logic, "figure out the difference between two directories", is tightly
+our domain logic, "figure out the difference between two directories," is tightly
 coupled to the IO code. We can't run our difference algorithm without calling
 the pathlib, shutil, and hashlib modules.
 
@@ -244,7 +244,7 @@ What could we do to abstract out the filesystem in each case?
 For (1) and (2), we've already intuitively started using an abstraction, a
 dictionary of hashes to paths, and you may already have been thinking, "why not
 use build up a dictionary for the destination folder as well as the source,
-then we just compare two dicts".  That seems like a very nice way to abstract
+then we just compare two dicts?"  That seems like a very nice way to abstract
 the current state of the filesystem.
 
     source_files = {'hash1': 'path1', 'hash2': 'path2'}
@@ -306,7 +306,7 @@ Let's see them in turn.
 
 ==== Option 1 - Functional Core, Imperative Shell. Ish.
 
-Let's call this the "Harry Way".  FCIS is probably a bit of an aspirational
+Let's call this the "Harry Way."  FCIS is probably a bit of an aspirational
 name, in fact the point is not to have a pure-functional solution in the 
 sense of not-using-classes, but more in the sense of having no (or minimal)
 side-effects.  The aim is to split out a core of business logic with minimal or
@@ -359,7 +359,7 @@ def determine_actions(src_hashes, dst_hashes, src_folder, dst_folder):  #<2>
 <1> The code to build up the dictionary of paths and hashes is now trivially
     easy to write.
 
-<2> The core of our "business logic", which says, given these two sets of
+<2> The core of our "business logic," which says, given these two sets of
     hashes and filenames, what should we copy/move/delete?  takes simple
     data structures and returns simple data structures
 
@@ -396,7 +396,7 @@ changes - from the low-level details of IO, we can easily test the core of our c
 
 ==== Dependency Injection
 
-Let's call this the "Bob way", and it's about making dependencies explicit and
+Let's call this the "Bob way," and it's about making dependencies explicit and
 modifiable:
 
 [[di_version]]
@@ -481,7 +481,7 @@ See <<chapter_10_dependency_injection>> for more exploration of making our
 dependency injection more explict and centralised.
 ******************************************************************************
 
-=== Wrap-up: "Depend on Abstractions".
+=== Wrap-up: "Depend on Abstractions."
 
 We'll see this idea come up again and again in the book: we can make our
 systems easier to test and maintain by simplifying the interface between our

--- a/appendix_bootstrap.asciidoc
+++ b/appendix_bootstrap.asciidoc
@@ -16,7 +16,7 @@ root" in OO parlance, is a pattern that can help us to keep things tidy.  Let's
 take a look.
 
 
-=== Defaults and config
+=== Defaults And Config
 
 Where do we declare our defaults?  _config.py_ is one place, but we also do
 some in, eg, _unit_of_work.py_, which declares the "default" database session
@@ -40,7 +40,7 @@ dependencies are, and we haven't even spoken about cross-cutting concerns
 like logging.
 
 
-=== Other setup code: initialisation
+=== Other Setup Code: Initialisation
 
 Defaults are maybe feeling a bit messy, but so are some other aspects of the
 initial setup or "bootsrapping" of our application; `orm.start_mappers()` for
@@ -69,7 +69,7 @@ Let's bring all this stuff together into a single "bootstrap script" and see
 if we end up in a better position.
 
 
-=== Bootstrap script
+=== Bootstrap Script
 
 Here's what a bootstrap script could look like:
 
@@ -96,7 +96,7 @@ def bootstrap(
 * it gives us back the core of our app, the messagebus
 
 
-=== Using bootstrap in our entrypoints
+=== Using Bootstrap In Our Entrypoints
 
 In our application's entrypoints, we just call `bootstrap.bootstrap()`
 to get a messagebus, rather than configuring a UoW and the rest of it.
@@ -157,7 +157,7 @@ def test_allocations_view(sqlite_bus):
 TODO: bootstrapper as class instead?
 
 
-=== Dependency diagrams
+=== Dependency Diagrams
 
 
 In chapter 9 it's a real mess.
@@ -184,4 +184,3 @@ Now we have what our esteemed tech reviewer David Seddon would call a "rocky roa
 flow in one direction.
 
 TODO: alternative fix by making an abstract redis thingie?  
-

--- a/appendix_csvs.asciidoc
+++ b/appendix_csvs.asciidoc
@@ -1,6 +1,6 @@
 [[appendix_csvs]]
 [appendix]
-== Swapping out the infrastructure: do everything with CSVs
+== Swapping Out The Infrastructure: Do Everything With CSVs
 
 This appendix is intended as a little illustration of the benefits of the
 _Repository_, _Unit of Work_ and _Service Layer_ patterns. It's intended to
@@ -182,7 +182,7 @@ with CSVs underlying them, instead of a database.  And as you'll see, it's
 actually quite straightforward.
 
 
-=== Implementing a Repository and Unit of Work for CSVs
+=== Implementing A Repository And Unit Of Work For CSVs
 
 
 Here's what a CSV-based repository could look like.  It abstracts away all the
@@ -299,4 +299,3 @@ Ta-da!   NOW ARE Y'ALL IMPRESSED OR WHAT?
 
 much love,
 Bob and Harry.
-

--- a/appendix_csvs.asciidoc
+++ b/appendix_csvs.asciidoc
@@ -3,7 +3,7 @@
 == Swapping Out The Infrastructure: Do Everything With CSVs
 
 This appendix is intended as a little illustration of the benefits of the
-_Repository_, _Unit of Work_ and _Service Layer_ patterns. It's intended to
+_repository_, _unit of work_ and _service layer_ patterns. It's intended to
 follow on from <<chapter_04_uow>>.
 
 Just as we finish building out our Flask API and getting it ready for release,
@@ -174,8 +174,8 @@ def test_cli_app_also_reads_existing_allocations_and_can_append_to_them(
 And we could keep hacking about and adding extra lines to that `load_batches` function,
 and some sort of way of tracking and saving new allocations... 
 
-But we already have a model for doing that!  It's called our Repository and our Unit
-of Work.
+But we already have a model for doing that!  It's called our _repository_ and our _unit
+of work_.
 
 All we need to do ("all we need to do") is reimplement those same abstractions, but
 with CSVs underlying them, instead of a database.  And as you'll see, it's
@@ -193,7 +193,7 @@ collection of domain objects.
 
 
 [[csv_repository]]
-.A Repository that uses CSV as its storage mechanism (src/allocation/csv_uow.py)
+.A repository that uses CSV as its storage mechanism (src/allocation/csv_uow.py)
 ====
 [source,python]
 ----

--- a/appendix_django.asciidoc
+++ b/appendix_django.asciidoc
@@ -1,6 +1,6 @@
 [[appendix_django]]
 [appendix]
-== Repository and Unit of Work patterns with Django
+== Repository And Unit Of Work Patterns With Django
 
 Supposing you wanted to use Django instead of SQLAlchemy and Flask, how
 might things look?
@@ -48,7 +48,7 @@ package next to our main allocation code:
 ====
 
 
-=== Repository pattern with Django
+=== Repository Pattern With Django
 
 I used a plugin called
 https://github.com/pytest-dev/pytest-django[pytest-django] to help with test
@@ -139,7 +139,7 @@ You can see that the implementation relies on the Django models having
 some custom methods for translating to and from our domain model.
 
 
-==== Custom methods on Django ORM classes to translate to/from our domain model
+==== Custom Methods On Django ORM Classes To Translate To/from Our Domain Model
 
 NOTE: As in <<chapter_02_repository>>, we use dependency inversion.
     The ORM (Django) depends on the model, and not the other way around
@@ -203,7 +203,7 @@ class OrderLine(models.Model):
 
 
 
-=== Unit of Work pattern with Django
+=== Unit Of Work Pattern With Django
 
 
 The tests don't change too much
@@ -304,7 +304,7 @@ class DjangoUnitOfWork(AbstractUnitOfWork):
 TODO: maybe `.seen()` should live on the uow not the repo
 
 
-=== API: Django views are adapters
+=== API: Django Views Are Adapters
 
 The Django _views.py_ file ends up being almost identical to the 
 old _flask_app.py_, because our architecture means it's a very
@@ -349,7 +349,7 @@ def allocate(request):
 ====
 
 
-=== Conclusions: would you bother?
+=== Conclusions: Would You Bother?
 
 OK it works but it does feel like more effort than Flask/SQLAlchemy.  Why is
 that, and when might you still choose Django?
@@ -371,4 +371,3 @@ So why might you still do it?
   and business logic from the ORM...)
   
 // TODO: Expand on this wrap-up?
-

--- a/appendix_project_structure.asciidoc
+++ b/appendix_project_structure.asciidoc
@@ -1,6 +1,6 @@
 [[appendix_project_structure]]
 [appendix]
-== A template project structure
+== A Template Project Structure
 
 Around <<chapter_03_service_layer>> we moved from just having
 everything in one folder to a more structured tree, and we thought it might
@@ -86,7 +86,7 @@ TODO: add more subfolders/structure inside our main source tree?
 
 
 
-=== env vars, 12-factor, and config, inside and outside containers.
+=== Env Vars, 12-factor, And Config, Inside And Outside Containers.
 
 The basic problem we're trying to solve here is that we need different
 config settings for:
@@ -159,7 +159,7 @@ def get_api_url():
     setup that "just works" (as much as possible).].
 
 
-=== docker-compose and containers config
+=== Docker-compose And Containers Config
 
 We use a lightweight docker container orchestration tool called docker-compose.
 It's main configuration is via a YAML file (sigh), <<docker_compose>>:
@@ -241,7 +241,7 @@ NOTE: Inside docker, other containers are available through hostnames named afte
     port defined in the `ports` section.
 
 
-=== Installing your source as a package
+=== Installing Your Source As A Package
 
 All our application code (everything except tests really) lives inside an
 _src_ folder, as in <<src_folder_tree>>:
@@ -362,4 +362,3 @@ config and so on.
 
 We've not needed to make tests pip-installable, but if you have difficulties with
 import paths, you might find it helps.
-

--- a/atlas.json
+++ b/atlas.json
@@ -68,7 +68,7 @@
     }
   },
   "theme": "oreillymedia/animal_theme_sass",
-  "title": "Lightweight Enterprise Architecture Patterns with Python",
+  "title": "Enterprise Architecture Patterns with Python",
   "print_isbn13": "9781492052203",
   "lang": "en",
   "accent_color": "",

--- a/chapter_01_domain_model.asciidoc
+++ b/chapter_01_domain_model.asciidoc
@@ -851,7 +851,7 @@ One final concept to cover, which is the idea that exceptions
 can be used to express domain concepts too.  In our conversations
 with the domain experts we've learned about the possibility that
 an order cannot be allocated because we are _Out of Stock_, and
-we can capture that using a Domain Exception:
+we can capture that using a _domain exception_:
 
 
 [[test_out_of_stock]]

--- a/chapter_01_domain_model.asciidoc
+++ b/chapter_01_domain_model.asciidoc
@@ -1,5 +1,5 @@
 [[chapter_01_domain_model]]
-== Domain modelling
+== Domain Modelling
 
 In the prologue, we used the term "business logic layer" to describe the
 central layer of a three-layered architecture. For the rest of the book, we're
@@ -8,7 +8,7 @@ community that does a better job of capturing our intended meaning (see the
 sidebar below for more on DDD).
 
 
-=== What is a domain model?
+=== What Is A Domain Model?
 
 The "domain" is a fancy way of saying "the problem you're trying to solve." We
 currently work for an online retailer of furniture. Depending on which system
@@ -142,7 +142,7 @@ Orders                          +------------+         Shipments, Stock
 
 
 
-=== Exploring the domain language
+=== Exploring The Domain Language
 
 Understanding the domain model takes time, and patience, and post-it notes. We
 have an initial conversation with our business experts and we agree a glossary
@@ -220,7 +220,7 @@ https://github.com/python-leap/code/tree/chapter_01_domain_model_exercise
 ******************************************************************************
 
 
-=== Unit testing Domain Models.
+=== Unit Testing Domain Models.
 
 We're not going to show you how TDD works in this book, but we want to show you
 how we would construct a model from this business conversation.
@@ -502,7 +502,7 @@ Please, please don't do this. Harry.] is a matter of debate.
 
 *******************************************************************************
 
-==== Dataclasses are great for Value Objects
+==== Dataclasses Are Great For Value Objects
 
 We've used the _line_ liberally in the previous code listings, but what is a
 line? In the business language, an _order_ has multiple _line_ items, where
@@ -626,7 +626,7 @@ def multiplying_two_money_values_is_an_error():
 
 
 
-==== Value Objects and Entities
+==== Value Objects And Entities
 
 An order line is uniquely identified by its orderid, sku and quantity; if we
 change one of those values, we now have a new line. That's the definition of a
@@ -728,7 +728,7 @@ on the attribute(s), like `.reference`, that define identity over time.
 //important (e.g. if you're using them in dictionaries or sets). I reckon it
 //might be worth spending more time on this.
 
-=== Not everything has to be an object: a domain service function
+=== Not Everything Has To Be An Object: A Domain Service Function
 
 We've made a model to represent Batches, but what we actually need
 to do is allocate order lines against a specific set of batches that
@@ -811,7 +811,7 @@ def allocate(line: OrderLine, batches: List[Batch]) -> str:
 ====
 
 
-==== Python's magic methods let us use our models with idomatic Python
+==== Python's Magic Methods Let Us Use Our Models With Idomatic Python
 
 You may or may not like the use of `next()` above, but we're pretty
 sure you'll agree that being able to use `sorted()` on our list of
@@ -840,7 +840,7 @@ class Batch:
 That's lovely.
 
 
-==== Exceptions can express domain concepts too
+==== Exceptions Can Express Domain Concepts Too
 
 One final concept to cover, which is the idea that exceptions
 can be used to express domain concepts too.  In our conversations

--- a/chapter_01_domain_model.asciidoc
+++ b/chapter_01_domain_model.asciidoc
@@ -39,9 +39,9 @@ too late, and OO-enthusiasts will tell you to look further back to Ivar
 Jacobson and Grady Booch; the term has been around since the mid-1980s.]
 and it's been a hugely successful movement in transforming the way people
 design software by focusing on the core business domain.  Many of the
-architecture patterns that we cover in this book, like Entity, Aggregate and
-Value Objects (see <<chapter_04_uow>>), and Repository Pattern (in <<chapter_02,the next
-chapter>>) all come from the DDD tradition.
+architecture patterns that we cover in this book, like _entity_, _aggregate_
+and _value objects_ (see <<chapter_04_uow>>), and _repository pattern_ (in
+<<chapter_02,the next chapter>>) all come from the DDD tradition.
 
 In a nutshell, the central conceit of DDD is that the most important thing
 about software is that it provides a model of the business.  If we get that
@@ -543,7 +543,7 @@ domain object that is uniquely identified by the data it holds.
 
 
 [[orderline_value_object]]
-.OrderLine is a Value Object.
+.OrderLine is a value object.
 ====
 [source,python]
 [role="skip"]
@@ -600,7 +600,7 @@ operators.
 
 
 [[value_object_maths]]
-.Maths with Value Objects.
+.Maths with value objects.
 ====
 [source,python]
 [role="skip"]
@@ -901,7 +901,7 @@ Domain modelling::
     the most likely to change, and the place where you deliver the
     most value to the business.  Make it easy to understand and modify
 
-Distinguish Entities from Value Objects::
+Distinguish entities from value objects::
     A "value object" is defined by its attributes.  It's usually best
     implemented as an immutable type.  If you change an attribute on
     a value object, it represents a different object.  In contrast,

--- a/chapter_01_domain_model.asciidoc
+++ b/chapter_01_domain_model.asciidoc
@@ -1,16 +1,16 @@
 [[chapter_01_domain_model]]
 == Domain Modelling
 
-In the prologue, we used the term "business logic layer" to describe the
+In the <<prologue>>, we used the term _business logic layer_ to describe the
 central layer of a three-layered architecture. For the rest of the book, we're
-going to use the term "domain model" instead. This is a term from the DDD
+going to use the term _domain model_ instead. This is a term from the DDD
 community that does a better job of capturing our intended meaning (see the
-sidebar below for more on DDD).
+next sidebar for more on DDD).
 
 
 === What Is A Domain Model?
 
-The "domain" is a fancy way of saying "the problem you're trying to solve." We
+The _domain_ is a fancy way of saying _the problem you're trying to solve._ We
 currently work for an online retailer of furniture. Depending on which system
 I'm talking about, the domain might be purchasing and procurement, or product
 design, or logistics and delivery. Most programmers spend their days trying to
@@ -40,7 +40,7 @@ Jacobson and Grady Booch; the term has been around since the mid-1980s.]
 and it's been a hugely successful movement in transforming the way people
 design software by focusing on the core business domain.  Many of the
 architecture patterns that we cover in this book, like Entity, Aggregate and
-Value Objects (see <<chapter_04_uow>>), Repository (in <<chapter_02,the next
+Value Objects (see <<chapter_04_uow>>), and Repository Pattern (in <<chapter_02,the next
 chapter>>) all come from the DDD tradition.
 
 In a nutshell, the central conceit of DDD is that the most important thing
@@ -55,8 +55,11 @@ But there's a lot more to DDD, and the processes, tools and techniques for
 developing a domain model.  We hope to give you a taste for it though,
 and cannot encourage you enough to go on and read a proper DDD book.
 
-* The original https://domainlanguage.com/ddd/[DDD "blue book"] by Eric Evans
-* Or some people prefer the https://amzn.to/2tidSLb["red book"], by Vaughn Vernon
+* The original https://domainlanguage.com/ddd/["blue book"],
+  _Domain-Driven Design_ by Eric Evans
+//TODO: proper book reference - author, name in italics, year, publisher
+* Or, some people prefer the https://amzn.to/2tidSLb["red book"],
+  _Implementing Domain-Driven Design_, by Vaughn Vernon
 
 *****************************************************************
 
@@ -92,7 +95,7 @@ in a specific way, we should listen to understand the deeper meaning and encode
 the hard-won experience into our software.
 
 We're going to use a real-world domain model throughout this book, specifically
-a model from our current employment. Made.com are a successful furniture
+a model from our current employment. Made.com is a successful furniture
 retailer. When you buy a sofa or a coffee table, we have to figure out how best
 to get your goods to your home.
 
@@ -145,7 +148,7 @@ Orders                          +------------+         Shipments, Stock
 === Exploring The Domain Language
 
 Understanding the domain model takes time, and patience, and post-it notes. We
-have an initial conversation with our business experts and we agree a glossary
+have an initial conversation with our business experts and we agree on a glossary
 and some rules for the first minimal version of the domain model. Wherever
 possible, we ask for concrete examples to illustrate each rule.
 
@@ -181,6 +184,7 @@ domain experts about allocation.
 ** I have a batch of 20 SMALL-TABLE, and I allocate an order line for 2
    SMALL-TABLE.
 ** The batch should have 18 SMALL-TABLE remaining.
+//TODO: CC asked us to change the "Is" to "we"s our "you"s here.
 
 * I can't allocate to a batch if the available quantity is less than the
   quantity of the order line.
@@ -220,7 +224,7 @@ https://github.com/python-leap/code/tree/chapter_01_domain_model_exercise
 ******************************************************************************
 
 
-=== Unit Testing Domain Models.
+=== Unit Testing Domain Models
 
 We're not going to show you how TDD works in this book, but we want to show you
 how we would construct a model from this business conversation.
@@ -278,7 +282,7 @@ class Batch:
 ====
 
 
-<1> OrderLine is an immutable dataclassfootnote:[In previous Python versions we
+<1> `OrderLine` is an immutable dataclassfootnote:[In previous Python versions we
     might have used a namedtuple.  You could also check out Hynek Schlawack's
     excellent https://pypi.org/project/attrs/[attrs].]
     with no behaviour.
@@ -289,8 +293,8 @@ class Batch:
     You may decide the price paid in terms of readability is too high.
 
 
-Our implementation here is trivial: a Batch just wraps an integer
-"available_quantity" and we decrement that value on allocation. We've written
+Our implementation here is trivial: a `Batch` just wraps an integer
+`available_quantity` and we decrement that value on allocation. We've written
 quite a lot of code just to subtract one number from another, but we think that
 modelling our domain precisely will pay off.
 
@@ -332,10 +336,10 @@ There's nothing too unexpected here. We've refactored our test suite so that we
 don't keep repeating the same lines of code to create a batch and a line for
 the same sku; and we've written four simple tests for a new method
 `can_allocate`. Again, notice that the names we use mirror the language of our
-domain experts, and the examples we agreed are directly written into code.
+domain experts, and the examples we agreed upon are directly written into code.
 
-We can implement this straightforwardly, too, by writing the can_allocate
-method of the Batch.
+We can implement this straightforwardly, too, by writing the `can_allocate`
+method of `Batch`.
 
 
 [[can_allocate]]
@@ -349,7 +353,7 @@ method of the Batch.
 ====
 
 Let's skip the deallocate method because we can trivially implement it as an
-increment of the Batch.available_quantity property, and jump to the next test:
+increment of the `Batch.available_quantity` property, and jump to the next test:
 
 
 [[test_deallocate_unallocated]]
@@ -365,9 +369,9 @@ def test_can_only_deallocate_allocated_lines():
 ====
 
 In this test we're asserting that deallocating a line from a batch has no effect
-unless the batch previously allocated the line. For this to work, our Batch
+unless the batch previously allocated the line. For this to work, our `Batch`
 needs to understand which lines have been allocated. Let's look at the
-implementation.
+implementation:
 
 
 [[domain_model_complete]]
@@ -438,7 +442,7 @@ class Batch:
 
 Now we're getting somewhere! A batch now keeps track of a set of allocated
 OrderLine objects. When we allocate, if we have enough available quantity, we
-just add to the set. Our available_quantity is now a calculated property:
+just add to the set. Our `available_quantity` is now a calculated property:
 purchased quantity - allocated quantity. Using a set here makes it simple for us
 to handle the last test, because items in a set are unique.
 
@@ -464,7 +468,7 @@ layering will help us to avoid a ball of mud.
 
 
 
-.More Types for more Type hints
+.More Types for More Type Hints
 *******************************************************************************
 
 If you really want to go to town with type hints, you could go as far as
@@ -530,11 +534,11 @@ Lines:
 
 
 Notice that while an order has a _reference_ that uniquely identifies it, a
-_line_ does not. (Even if we add the order ID to the OrderLine class,
+_line_ does not. (Even if we add the order reference to the `OrderLine` class,
 it's not something that uniquely identifies the line itself).
 
 Whenever we have a business concept that has some data but no identity, we
-often choose to represent it using a _Value Object_. A value object is any
+often choose to represent it using a _value object_. A value object is any
 domain object that is uniquely identified by the data it holds.
 
 
@@ -552,14 +556,14 @@ class OrderLine:
 ----
 ====
 
-Introduced in Python 3.7, Dataclasses are a neat way to represent value objects;
+Introduced in Python 3.7, `Dataclasses` are a neat way to represent value objects;
 if you're on Python 2, you could use named tuples instead. Either technique
 will give you _value equality_ which is the fancy way of saying "two lines with
 the same orderid, sku and qty are equal."
 
 
 [[more_value_objects]]
-.More examples of Value Objects
+.More examples of value objects
 ====
 [source,python]
 [role="skip"]
@@ -587,7 +591,7 @@ def test_equality():
 ====
 
 These value objects match our real-world intuitions about how their values work.
-It doesn't matter _which_ £10 note we're talking about, because they all have
+It doesn't matter _which_ $10 note we're talking about, because they all have
 the same value. Likewise two names are equal if both the first and last name
 match, and two lines are equivalent if they have the same customer order, product code and
 quantity. We can still have complex behaviour on a value object, though. In
@@ -635,11 +639,11 @@ long-lived identity. What about a batch though? That _is_ identified by a
 reference.
 
 We use the term _entity_ to describe a domain object that has long-lived
-identity. On the previous page we introduced a _Name_ class as a value object.
+identity. On the previous page we introduced a `Name` class as a value object.
 If we take the name "Harry Percival" and change one letter, we have the new
 Name object "Barry Percival."
 
-It should be clear that "Harry Percival" is not equal to "Barry Percival."
+It should be clear that "Harry Percival" is not equal to "Barry Percival":
 
 
 [[test_equality]]
@@ -720,32 +724,33 @@ For both entity and value objects it's also worth thinking through how
 behaviour of objects when you add them to sets or use them as dict keys;
 more info https://docs.python.org/3/glossary.html#term-hashable[in the Python docs].
 
-For Value Objects, the hash should be based on all the value attributes.
-For Entities, the hash should either be `None`, or it should be based
+For value objects, the hash should be based on all the value attributes.
+For entities, the hash should either be `None`, or it should be based
 on the attribute(s), like `.reference`, that define identity over time.
 
 //TODO (DS) Getting hash values right for these kinds of objects is quite
 //important (e.g. if you're using them in dictionaries or sets). I reckon it
 //might be worth spending more time on this.
 
+
 === Not Everything Has To Be An Object: A Domain Service Function
 
-We've made a model to represent Batches, but what we actually need
+We've made a model to represent batches, but what we actually need
 to do is allocate order lines against a specific set of batches that
 represent all our stock.
 
-[quote, Eric Evans (in the DDD book)]
+[quote, Eric Evans, Domain-Driven Design]
 ____
-Sometimes, it just isn't a thing.
+Sometimes, it just isn't a Thing.
 ____
 
-Evans discusses the idea of "domain services"footnote:[Domain Services are
+Evans discusses the idea of "domain services"footnote:[Domain services are
 not the same thing as the services from the
-<<chapter_03_service_layer,Service Layer>>, although they are
-often closely related.  A Domain Service represents a business concept or
+<<chapter_03_service_layer,service layer>>, although they are
+often closely related.  A domain service represents a business concept or
 process, whereas a service-layer service represents a use case for your
-application.  Often the service layer will call a domain service]
-operations that don't have a natural home in an Entity or Value object.  A
+application.  Often the service layer will call a domain service.]
+operations that don't have a natural home in an entity or value object.  A
 thing that allocates an order line, given a set of batches, sounds a lot like a
 function, and we can take advantage of the fact that Python is a multi-paradigm
 language and just make it a function.

--- a/chapter_01_domain_model.asciidoc
+++ b/chapter_01_domain_model.asciidoc
@@ -10,7 +10,7 @@ sidebar below for more on DDD).
 
 === What is a domain model?
 
-The "domain" is a fancy way of saying "the problem you're trying to solve". We
+The "domain" is a fancy way of saying "the problem you're trying to solve." We
 currently work for an online retailer of furniture. Depending on which system
 I'm talking about, the domain might be purchasing and procurement, or product
 design, or logistics and delivery. Most programmers spend their days trying to
@@ -74,13 +74,13 @@ to figure out, from first principles, how to navigate home.
 In your first few days, you might just push buttons randomly, but soon you'd
 learn which buttons did what, so that you could give one another instructions.
 "Press the red button near the flashing doo-hickey and then throw that big
-lever over by the radar gizmo", you might say.
+lever over by the radar gizmo," you might say.
 
 Within a couple of weeks, you'd become more precise as you adopted words to
 describe the ship's functions: "increase oxygen levels in cargo bay three"
-or "turn on the little thrusters". After a few months you'd have adopted
-language for entire complex processes: "Start landing sequence", or "prepare
-for warp". This process would happen quite naturally, without any formal effort
+or "turn on the little thrusters." After a few months you'd have adopted
+language for entire complex processes: "Start landing sequence," or "prepare
+for warp." This process would happen quite naturally, without any formal effort
 to build a shared glossary.
 
 So it is in the mundane world of business. The terminology used by business
@@ -156,7 +156,7 @@ so that the examples are easier to talk about.
 Here are some notes we might have taken while having a conversation with our
 domain experts about allocation.
 
-* A _product_ is identified by a _sku_, pronounced "skew", which is short for
+* A _product_ is identified by a _sku_, pronounced "skew," which is short for
   "Stock Keeping Unit."
 
 * _Customers_ place _orders_. An order is identified by an _order reference_,
@@ -555,7 +555,7 @@ class OrderLine:
 Introduced in Python 3.7, Dataclasses are a neat way to represent value objects;
 if you're on Python 2, you could use named tuples instead. Either technique
 will give you _value equality_ which is the fancy way of saying "two lines with
-the same orderid, sku and qty are equal".
+the same orderid, sku and qty are equal."
 
 
 [[more_value_objects]]
@@ -637,9 +637,9 @@ reference.
 We use the term _entity_ to describe a domain object that has long-lived
 identity. On the previous page we introduced a _Name_ class as a value object.
 If we take the name "Harry Percival" and change one letter, we have the new
-Name object "Barry Percival".
+Name object "Barry Percival."
 
-It should be clear that "Harry Percival" is not equal to "Barry Percival".
+It should be clear that "Harry Percival" is not equal to "Barry Percival."
 
 
 [[test_equality]]

--- a/chapter_02_repository.asciidoc
+++ b/chapter_02_repository.asciidoc
@@ -240,7 +240,7 @@ way around.
 
 Django doesn't provide an equivalent for SQLAlchemy's "classical mapper,"
 but see <<appendix_django>> for some examples of how you apply dependency
-inversion and the Repository Pattern to Django.
+inversion and the repository pattern to Django.
 
 *******************************************************************************
 
@@ -346,7 +346,7 @@ def test_orderline_mapper_can_save_lines(session):
 You probably wouldn't keep these tests around--as we'll see shortly, once
 you've taken the step of inverting the dependency of ORM and domain model, it's
 only a small additional step to implement an additional abstraction called the
-Repository pattern, which will be easier to write tests against, and will
+repository pattern, which will be easier to write tests against, and will
 provide a simple, common interface for faking out later in tests.
 
 // TODO (DS): Not sure how valuable this bit about getting the orm directly is.
@@ -511,7 +511,7 @@ and although we may hope it will be reducing complexity overall, it does add
 complexity locally, and it has a cost in terms raw numbers of moving parts and
 ongoing maintenance.
 
-Repository pattern is probably one of the easiest choices in the book though,
+_Repository pattern_ is probably one of the easiest choices in the book though,
 if you've already heading down the DDD and dependency inversion route.  As far
 as our code is concerned, we're really just swapping the SQLAlchemy abstraction
 (`session.query(Batch)`) for a different one (`batches_repo.get`) which we
@@ -523,7 +523,7 @@ simple abstraction over our storage layer, which we control. It would make
 it very easy to make fundamental changes to the way we store things (see
 <appendix_csvs>>), and as we'll see, it is very easy to fake out for unit tests.
 
-In addition, "Repository pattern" is so common in the DDD world that, if you
+In addition, repository pattern is so common in the DDD world that, if you
 do collaborate with programmers that have come to Python from the Java and C#
 worlds, they're likely to recognise it.
 
@@ -720,7 +720,7 @@ but the nice thing is--the rest of your application just doesn't care.
 
 === Building A Fake Repository For Tests Is Now Trivial!
 
-Here's one of the biggest benefits of Repository pattern.
+Here's one of the biggest benefits of _repository pattern_.
 
 
 [[fake_repository]]

--- a/chapter_02_repository.asciidoc
+++ b/chapter_02_repository.asciidoc
@@ -145,7 +145,7 @@ yourself questions like this:
 
 Although some people like to nitpick over the differences, all these are
 pretty much names for the same thing, and they all boil down to the
-Dependency Inversion Principle--high-level modules (the domain) should
+dependency inversion principle--high-level modules (the domain) should
 not depend on low-level ones (the infrastructure).footnote:[Mark Seeman has
 https://blog.ploeh.dk/2013/12/03/layers-onions-ports-adapters-its-all-the-same/[an excellent blog post]
 on the topic, which we recommend.]

--- a/chapter_02_repository.asciidoc
+++ b/chapter_02_repository.asciidoc
@@ -103,14 +103,14 @@ separate (which is a good thing), and to have each layer depend only on the one
 below...
 
 But we want our domain model to have __no dependencies whatsoever__footnote:[
-I suppose we mean, "no external dependencies".  Standard library dependencies are
+I suppose we mean, "no external dependencies."  Standard libray dependencies are
 fine, depending on an ORM or a web framework is not].
 We don't want infrastructure concerns bleeding over into our domain model and
 slowing down our unit tests or our ability to make changes.
 
 Instead, as discussed in the prologue, we'll think of our model as being on the
-"inside", and dependencies flowing inwards to it;  what people sometimes call
-"onion architecture".
+"inside," and dependencies flowing inwards to it;  what people sometimes call
+"onion architecture."
 
 [[onion_architecture]]
 .Onion Architecture
@@ -150,7 +150,7 @@ not depend on low-level ones (the infrastructure).footnote:[Mark Seeman has
 https://blog.ploeh.dk/2013/12/03/layers-onions-ports-adapters-its-all-the-same/[an excellent blog post]
 on the topic, which we recommend.]
 
-We'll get into some of the nitty-gritty around "depending on abstractions",
+We'll get into some of the nitty-gritty around "depending on abstractions,"
 and whether there is a Pythonic equivalent of interfaces, later in the book.
 *******************************************************************************
 
@@ -238,7 +238,7 @@ The point is the same -- our model classes inherit directly from ORM
 classes, so our model depends on the ORM.  We want it to be the other
 way around.
 
-Django doesn't provide an equivalent for SQLAlchemy's "classical mapper",
+Django doesn't provide an equivalent for SQLAlchemy's "classical mapper,"
 but see <<appendix_django>> for some examples of how you apply dependency
 inversion and the Repository Pattern to Django.
 
@@ -338,7 +338,7 @@ def test_orderline_mapper_can_save_lines(session):
 <1> If you've not used pytest, the `session` argument to this test needs
     explaining.  You don't need to worry about the details of pytest or its
     fixtures for the purposes of this book, but the short explanation is that
-    you can define common dependencies for your tests as "fixtures", and
+    you can define common dependencies for your tests as "fixtures," and
     pytest will inject them to the tests that need them by looking at their
     function arguments.  In this case, it's a SQLAlchemy database session.
 
@@ -503,7 +503,7 @@ of nothing.
 ____
 
 Whenever we introduce an architectural pattern in this book, we'll always be
-trying to ask: "what do we get for this?  And what does it cost us?".
+trying to ask: "what do we get for this?  And what does it cost us?."
 
 
 Usually at the very least we'll be introducing an extra layer of abstraction,
@@ -558,7 +558,7 @@ TODO: not sure if this diagram is helping.
 
 
 As always, we start with a test. This would probably be classified as an
-"integration test", since we're checking that our code (the repository) is
+"integration test," since we're checking that our code (the repository) is
 correctly integrated with the database;  hence, the tests tend to mix
 raw SQL with calls and assertions on our own code.
 
@@ -705,7 +705,7 @@ def allocate_endpoint():
 .Exercise for the Reader
 ******************************************************************************
 We bumped into a friend at a DDD conference the other day who said "I haven't
-used an ORM in 10 years".  Repository pattern and an ORM both act as abstractions
+used an ORM in 10 years."  Repository pattern and an ORM both act as abstractions
 in front of raw SQL, so using one behind the other isn't really necessary.  Why
 not have a go at implementing our repository without using the ORM?
 

--- a/chapter_02_repository.asciidoc
+++ b/chapter_02_repository.asciidoc
@@ -35,7 +35,7 @@ storage, and this is a textbook, so we can allow ourselves a tiny bit more
 bottom-up development, and start to think about storage and databases.
 
 
-=== Some pseudocode: what are we going to need?
+=== Some Pseudocode: What Are We Going To Need?
 
 When we build our first API endpoint, we know we're going to have
 some code that looks more or less like <<api_endpoint_pseudocode>>
@@ -69,7 +69,7 @@ model objects from it, and we'll also need a way of saving them back to the
 database.
 
 
-=== Applying the Dependency Inversion Principle to the Database
+=== Applying The Dependency Inversion Principle To The Database
 
 As mentioned in <<part1_prologue>>, the "layered architecture" is a common
 approach to structuring a system that has a UI, some logic, and a database:
@@ -155,7 +155,7 @@ and whether there is a Pythonic equivalent of interfaces, later in the book.
 *******************************************************************************
 
 
-==== The "normal" ORM way: model depends on ORM.
+==== The "normal" ORM Way: Model Depends On ORM.
 
 In 2019 it's unlikely that your team are hand-rolling their own SQL queries.
 Instead, you're almost certainly using some kind of framework to generate
@@ -246,7 +246,7 @@ inversion and the Repository Pattern to Django.
 
 
 
-==== Inverting the dependency: ORM depends on model.
+==== Inverting The Dependency: ORM Depends On Model.
 
 Well, thankfully, that's not the only way to use SQLAlchemy.  The alternative is
 to define your schema separately, and an explicit _mapper_ for how to convert
@@ -437,7 +437,7 @@ find them again. Our in memory data would let us add new objects, just like a
 list or a set, and since the objects are in memory we never need to call a
 "Save" method, we just fetch the object we care about, and modify it in memory.
 
-==== The repository in the abstract
+==== The Repository In The Abstract
 
 The simplest repository has just two methods: `add` to put a new item in the
 repository, and `get` to return a previously added item.footnote:[
@@ -493,7 +493,7 @@ WARNING: We're using abstract base classes in this book for didactic reasons:
 NOTE: To really reap the benefits of ABCs (such as they may be) you'll want to
     be running some helpers like `pylint` and `mypy`.
 
-==== What is the trade-off?
+==== What Is The Trade-off?
 
 [quote, Rich Hickey]
 ____
@@ -718,7 +718,7 @@ but the nice thing is--the rest of your application just doesn't care.
 ******************************************************************************
 
 
-=== Building a fake repository for tests is now trivial!
+=== Building A Fake Repository For Tests Is Now Trivial!
 
 Here's one of the biggest benefits of Repository pattern.
 

--- a/chapter_03_service_layer.asciidoc
+++ b/chapter_03_service_layer.asciidoc
@@ -1,5 +1,5 @@
 [[chapter_03_service_layer]]
-== Our first use case:  Flask API and service layer.
+== Our First Use Case: Flask API And Service Layer.
 
 Like any good agile team, we're hustling to try and get an MVP out and
 in front of the users to start gathering feedback.  We have the core
@@ -29,7 +29,7 @@ plan:
   storage layer to set up test data.
 
 
-=== A first end-to-end (E2E) test
+=== A First End-to-end (E2E) Test
 
 No-one is interested in getting into a long terminology debate about what
 counts as an E2E test vs a functional test vs an acceptance test vs an
@@ -88,7 +88,7 @@ also talking to a postgres database.  If you want to see how we did
 it, check out <<appendix_project_structure>>.
 
 
-=== The straightforward implementation
+=== The Straightforward Implementation
 
 Implementing things in the most obvious way, you might get something like this:
 
@@ -171,7 +171,7 @@ Not quite so lovely, but that will force us to get a commit in.
 
 
 
-=== Error conditions that require database checks
+=== Error Conditions That Require Database Checks
 
 If we keep going like this though, things are going to get uglier and uglier.
 
@@ -280,7 +280,7 @@ E2E tests is starting to get out of control, and soon we'll end up with an
 inverted test pyramid (or "ice cream cone model" as Bob likes to call it).
 
 
-=== Introducing a service layer, and using FakeRepository to unit test it
+=== Introducing A Service Layer, And Using Fakerepository To Unit Test It
 
 If we look at what our Flask app is doing, there's quite a lot of what we
 might call "orchestration" -- fetching stuff out of our repository, validating
@@ -422,7 +422,7 @@ def test_commits():
 ====
 
 
-==== A typical service function
+==== A Typical Service Function
 
 We'll get to a service function that looks something like <<service_function>>:
 
@@ -603,7 +603,7 @@ We've successfully split our tests into two broad categories: tests about web
 stuff, which we implement end-to-end; and tests about orchestration stuff, which
 we can test against the service layer in memory.
 
-=== How is our test pyramid looking?
+=== How Is Our Test Pyramid Looking?
 
 Let's see what this move to using a service layer, with its own service-layer tests,
 does to our test pyramid:
@@ -633,7 +633,7 @@ a healthy-looking test pyramid.
 
 
 
-=== Should domain layer tests move to the service layer?
+=== Should Domain Layer Tests Move To The Service Layer?
 
 We could take this a step further. Since we can test the our software against
 the service layer, we don't really need tests for the domain model any more.
@@ -706,7 +706,7 @@ we won't have any tests that directly interact with "private" methods or
 attributes on our model objects, which leaves us more free to refactor them.
 
 
-=== On deciding what kind of tests to write
+=== On Deciding What Kind Of Tests To Write
 
 You might be asking yourself "should I rewrite all my unit tests, then? Is it
 wrong to write tests against the domain model?" To answer the question, it's
@@ -764,7 +764,7 @@ implementation.
 // layer
 
 
-==== Low and High Gear
+==== Low And High Gear
 
 Most of the time, when we are adding a new feature, or fixing a bug, we don't
 need to make extensive changes to the domain model. In these cases, we prefer
@@ -807,7 +807,7 @@ hazard, we again drop down to a low gear until we can pick up speed again.
 ******************************************************************************
 
 
-=== Fully Decoupling the service layer tests from the domain
+=== Fully Decoupling The Service Layer Tests From The Domain
 
 We still have some direct dependencies on the domain in our service-layer
 tests, because we use domain objects to set up our test data and to invoke
@@ -869,7 +869,7 @@ But our tests still depend on the domain, because we still manually instantiate
 model works, we'll have to change a bunch of tests.
 
 
-==== Mitigation: keep all domain dependencies in fixture functions
+==== Mitigation: Keep All Domain Dependencies In Fixture Functions
 
 We could at least abstract that out to a helper function or a fixture
 in our tests.  Here's one way you could do that, adding a factory
@@ -904,7 +904,7 @@ At least that would move all of our tests' dependencies on the domain
 into one place.
 
 
-==== Adding a missing service
+==== Adding A Missing Service
 
 We could go one step further though.  If we had a service to add stock,
 then we could use that, and make our service-layer tests fully expressed
@@ -988,7 +988,7 @@ This is a really nice place to be in.  Our service-layer tests only depend on
 the services layer itself, leaving us completely free to refactor the model as
 we see fit.
 
-=== Carrying the improvement through to the E2E tests
+=== Carrying The Improvement Through To The E2E Tests
 
 In the same way that adding `add_batch` helped decouple our services-layer
 tests from the model, adding an API endpoint to add a batch would remove
@@ -1175,4 +1175,3 @@ layer is tightly coupled to a `session` object.  In the next chapter, we'll
 introduce one more pattern that works closely with _Repository_ and _Service
 Layer_, the _Unit of Work_ pattern, and everything will be absolutely lovely.
 You'll see!
-

--- a/chapter_03_service_layer.asciidoc
+++ b/chapter_03_service_layer.asciidoc
@@ -15,10 +15,10 @@ plan:
   an end-to-end test and some quick and dirty SQL to prepare test
   data.
 
-* Refactor out a _Service Layer_ to serve as an abstraction to
+* Refactor out a _service layer_ to serve as an abstraction to
   capture the use case, and sit between Flask and our Domain Model.
   Build some service-layer tests and show how they can use the
-  FakeRepository.
+  `FakeRepository`.
 
 * Experiment with different types of parameters for our service layer
   functions; show that using primitive data types allows the service-layer's

--- a/chapter_03_service_layer.asciidoc
+++ b/chapter_03_service_layer.asciidoc
@@ -1172,6 +1172,6 @@ TODO: not sure if this diagram is helping.
 
 There's still a bit of awkwardness we'd like to get rid of. The service
 layer is tightly coupled to a `session` object.  In the next chapter, we'll
-introduce one more pattern that works closely with _Repository_ and _Service
-Layer_, the _Unit of Work_ pattern, and everything will be absolutely lovely.
+introduce one more pattern that works closely with _repository_ and _service
+layer_, the _unit of work_ pattern, and everything will be absolutely lovely.
 You'll see!

--- a/chapter_03_service_layer.asciidoc
+++ b/chapter_03_service_layer.asciidoc
@@ -35,7 +35,7 @@ No-one is interested in getting into a long terminology debate about what
 counts as an E2E test vs a functional test vs an acceptance test vs an
 integration test vs unit tests.  Different projects need different combinations
 of tests, and we've seen perfectly successful projects just split things into
-"fast tests" and "slow tests".
+"fast tests" and "slow tests."
 
 For now we want to write one or maybe two tests that are going to exercise
 a "real" API endpoint (using HTTP) and talk to a real database. Let's call
@@ -290,8 +290,8 @@ web API endpoint (you'd need them if you were building a CLI for example, see
 <<appendix_csvs>>), and they're not really things that need to be tested by
 end-to-end tests.
 
-It often makes sense to split out a "service layer", sometimes called
-"orchestration layer" or "use case layer".
+It often makes sense to split out a "service layer," sometimes called
+"orchestration layer" or "use case layer."
 
 Do you remember the `FakeRepository` that we prepared in the last chapter?
 
@@ -484,8 +484,8 @@ and we've used the type hint to say that we depend on ``AbstractRepository``foot
 Is this Pythonic?  Depending on who you ask, both abstract base classes and
 type hints are hideous abominations, and serve only to add useless, unreadable
 cruft to your code; beloved only by people who wish that Python was Haskell,
-which it will never be.  "beautiful is better than ugly", "simple is better
-than complex", and "readability counts"...
+which it will never be.  "beautiful is better than ugly," "simple is better
+than complex," and "readability counts..."
 Or, perhaps they make explicit something that would otherwise be implicit
 ("explicit is better than implicit").  For the purposes of this book, we've
 decided this argument carries the day. What you decide to do in your own
@@ -709,7 +709,7 @@ attributes on our model objects, which leaves us more free to refactor them.
 === On deciding what kind of tests to write
 
 You might be asking yourself "should I rewrite all my unit tests, then? Is it
-wrong to write tests against the domain model?". To answer the question, it's
+wrong to write tests against the domain model?" To answer the question, it's
 important to understand the trade-off between coupling and design feedback.
 
 .The test spectrum
@@ -727,7 +727,7 @@ important to understand the trade-off between coupling and design feedback.
 
 //TODO: stick a non-ascii diagram here.
 
-Extreme Programming (XP) exhorts us to "listen to the code". When we're writing
+Extreme Programming (XP) exhorts us to "listen to the code." When we're writing
 tests, we might find that the code is hard to use, or notice a code smell. This
 is a trigger for us to refactor, and reconsider our design.
 
@@ -1097,7 +1097,7 @@ https://github.com/python-leap/code/tree/chapter_03_service_layer_exercise
 Adding the service layer has really bought us quite a lot:
 
 * Our flask API endpoints become very thin and easy to write:  their
-  only responsibility is doing "web stuff", things like parsing JSON
+  only responsibility is doing "web stuff," things like parsing JSON
   and producing the right HTTP codes for happy or unhappy cases.
 
 * We've defined a clear API for our domain, a set of use cases or

--- a/chapter_04_uow.asciidoc
+++ b/chapter_04_uow.asciidoc
@@ -1,5 +1,5 @@
 [[chapter_04_uow]]
-== Unit of Work pattern
+== Unit Of Work Pattern
 
 In this chapter we'll introduce a final piece of the puzzle that really pulls
 the _Repository_ and _Service layer_ patterns together, the _Unit of Work_
@@ -40,7 +40,7 @@ the end, some different handling for error and success cases?  Something like
 
 A context manager.
 
-=== Test-driving a UoW with integration tests
+=== Test-driving A Uow With Integration Tests
 
 Here's a test for a new "Unit of Work" (or UoW, which we pronounce, you-wow).
 It's a context manager that allows us to start a transaction, retrieve and get
@@ -98,7 +98,7 @@ def test_uow_can_retrieve_a_batch_and_allocate_to_it(session_factory):
 <3> And we call `commit()` on it when we're done.
 
 
-=== Unit of Work and its context manager
+=== Unit Of Work And Its Context Manager
 
 In our tests we've implicitly defined an interface for what a unit
 of work needs to do, let's make that explicit by using an abstract
@@ -153,7 +153,7 @@ class AbstractUnitOfWork(abc.ABC):
     is needed because different subclasses will want to initialise repositories
     in slightly different ways, this just gives us a single place to do that.
 
-==== The Real Unit of Work uses SqlAlchemy Sessions
+==== The Real Unit Of Work Uses Sqlalchemy Sessions
 
 [[unit_of_work]]
 .the real SQLAlchemy unit of work (src/allocation/unit_of_work.py)
@@ -193,7 +193,7 @@ class SqlAlchemyUnitOfWork(AbstractUnitOfWork):
 
 
 
-=== Fake Unit of Work for testing:
+=== Fake Unit Of Work For Testing:
 
 Here's how we use a fake unit of work in our service layer tests
 
@@ -262,7 +262,7 @@ I think of "Don't mock what you don't own" as referring specifically to "mock ve
 https://github.com/python-leap/book/issues/44
 ////
 
-=== Using the UoW in the service layer
+=== Using The Uow In The Service Layer
 
 And here's what our new service layer looks like:
 
@@ -300,7 +300,7 @@ def allocate(
     on an _abstract_ unit of work.
 
 
-=== Explicit tests for commit/rollback behaviour
+=== Explicit Tests For Commit/rollback Behaviour
 
 To convince ourselves that the commit/rollback behaviour works, we wrote
 a couple of tests:
@@ -344,7 +344,7 @@ TIP: We haven't shown it here, but it can be worth testing some of the more
     class makes that easy!
 
 
-=== Explicit vs implicit commits
+=== Explicit Vs Implicit Commits
 
 A brief digression on different ways of implementing the UoW pattern.
 
@@ -418,13 +418,13 @@ next time?  But you should experiment and figure out your own preferences here.
 // hard, presumably.
 
 
-=== Examples: Using UoW to group multiple operations into an atomic unit
+=== Examples: Using Uow To Group Multiple Operations Into An Atomic Unit
 
 Here's a few examples showing the unit of work pattern in use.  You can
 see how it leads to simple reasoning about what blocks of code happen
 together:
 
-==== Example 1: reallocate
+==== Example 1: Reallocate
 
 Supposing we want to be able to deallocate and then reallocate orders?
 
@@ -450,7 +450,7 @@ def reallocate(line: OrderLine, uow: AbstractUnitOfWork) -> str:
     the `deallocate()`, either.
 
 
-==== Example 2: change batch quantity
+==== Example 2: Change Batch Quantity
 
 Our shipping company gives us a call to say that one of the container doors
 opened and half our sofas have fallen into the Indian Ocean.  oops!
@@ -477,7 +477,7 @@ def change_batch_quantity(batchref: str, new_qty: int, uow: AbstractUnitOfWork):
     at any stage, we probably want to commit none of the changes.
 
 
-=== Tidying up the integration tests
+=== Tidying Up The Integration Tests
 
 We now have three sets of tests all essentially pointing at the database,
 _test_orm.py_, _test_repository.py_ and _test_uow.py_.  Should we throw any

--- a/chapter_04_uow.asciidoc
+++ b/chapter_04_uow.asciidoc
@@ -42,7 +42,7 @@ A context manager.
 
 === Test-driving A Uow With Integration Tests
 
-Here's a test for a new "Unit of Work" (or UoW, which we pronounce, you-wow).
+Here's a test for a new _Unit of Work_ (or UoW, which we pronounce "you-wow").
 It's a context manager that allows us to start a transaction, retrieve and get
 things from repos, and commit:
 
@@ -583,7 +583,7 @@ _Unit of work_ is an abstraction around data integrity::
     end of an operation.
 
 It works closely with _repository_ and _service layer_::
-    The Unit of Work pattern completes our abstractions over data-access by
+    The unit of work pattern completes our abstractions over data-access by
     representing atomic updates.
     Each of our service-layer use-cases runs in a single unit of work which
     succeeds or fails as a block.

--- a/chapter_04_uow.asciidoc
+++ b/chapter_04_uow.asciidoc
@@ -2,7 +2,7 @@
 == Unit Of Work Pattern
 
 In this chapter we'll introduce a final piece of the puzzle that really pulls
-the _Repository_ and _Service layer_ patterns together, the _Unit of Work_
+the _repository_ and _service layer_ patterns together, the _unit of work_
 pattern.
 
 //TODO: Big Lebowski illustration
@@ -552,10 +552,10 @@ Why do we go to the effort of abstracting away the SQLAlchemy session if it
 already implements the pattern we want?
 
 For one thing, the Session API is rich and supports operations that we don't
-want or need in our domain. Our UnitOfWork simplifies the Session to its
+want or need in our domain. Our `UnitOfWork` simplifies the Session to its
 essential core: it can be started, committed, or thrown away.
 
-For another, we're using the UnitOfWork to access our _Repository_ objects.
+For another, we're using the `UnitOfWork` to access our `Repository` objects.
 This is a neat bit of developer usability that we couldn't do with a plain
 SQLAlchemy Session.
 
@@ -575,14 +575,14 @@ SQLAlchemy's own recommendations:
 // the uow into a uow plus a uowm.
 
 
-.Unit of Work pattern: wrap-up
+.Unit of Work Pattern: Wrap-up
 *****************************************************************
-Unit of Work is an abstraction around data integrity::
+_Unit of work_ is an abstraction around data integrity::
     It helps to enforce the consistency of our domain model, and improves
     performance, by letting us perform a single _flush_ operation at the
     end of an operation.
 
-It works closely with repository and service layer::
+It works closely with _repository_ and _service layer_::
     The Unit of Work pattern completes our abstractions over data-access by
     representing atomic updates.
     Each of our service-layer use-cases runs in a single unit of work which
@@ -594,8 +594,8 @@ This is a lovely case for a context manager::
     which means the system is safe by default.
 
 SqlAlchemy already implements this pattern::
-    We introduce a simpler abstraction over the SQLAlchemy Session object in
-    order to "narrow" the interface between the ORM and our code. This helps
+    We introduce an even simpler abstraction over the SQLAlchemy Session object
+    in order to "narrow" the interface between the ORM and our code. This helps
     to keep us loosely coupled.
 
 *****************************************************************

--- a/chapter_04_uow.asciidoc
+++ b/chapter_04_uow.asciidoc
@@ -544,8 +544,8 @@ This pattern is so useful, in fact, that SQLAlchemy already uses a unit-of-work
 in the shape of the Session object. The Session object in SqlAlchemy is the way
 that your application loads data from the database.
 
-Every time you load a new Entity from the db, the Session begins to _track_
-changes to the Entity, and when the Session is _flushed_, all your changes are
+Every time you load a new entity from the db, the Session begins to _track_
+changes to the entity, and when the Session is _flushed_, all your changes are
 persisted together.
 
 Why do we go to the effort of abstracting away the SQLAlchemy session if it

--- a/chapter_04_uow.asciidoc
+++ b/chapter_04_uow.asciidoc
@@ -401,7 +401,7 @@ easier to reason about because there's only one code path that leads to changes
 in the system: total success and an explicit commit. Any other code path, any
 exception, any early exit from the uow's scope, leads to a safe state.
 
-Similarly, we prefer "always-rollback" to "only-rollback-on-error",  because
+Similarly, we prefer "always-rollback" to "only-rollback-on-error,"  because
 the former feels easier to understand;  rollback rolls back to the last commit,
 so either the user did one, or we blow their changes away.  Harsh but simple.
 

--- a/chapter_05_aggregate.asciidoc
+++ b/chapter_05_aggregate.asciidoc
@@ -1,5 +1,5 @@
 [[chapter_05_aggregate]]
-== Aggregates and consistency boundaries
+== Aggregates And Consistency Boundaries
 
 What's the point of a domain model anyway? What's the fundamental problem
 we're trying to addresss?
@@ -54,7 +54,7 @@ don't break the invariants.
 If we're unable to meet our invariants, we might choose to raise an error rather
 than complete the operation.
 
-=== Invariants and Concurrency
+=== Invariants And Concurrency
 
 In a single threaded single user application it's easy for us to maintain the
 invariants of our system. We can just allocate stock, one line at a time, and
@@ -76,7 +76,7 @@ order lines, we can't hold a lock over the whole `batches` table for
 every single one.
 
 
-=== Choosing the right Aggregate
+=== Choosing The Right Aggregate
 
 [quote, Eric Evans, DDD blue book]
 ____
@@ -243,7 +243,7 @@ do them for you by magic!
 
 ******************************************************************************
 
-=== Version numbers
+=== Version Numbers
 
 We've got our new aggregate and we're using it in all the right places, the remaining
 question is:  how will we actually enforce our data integrity rules?  We don't want
@@ -315,7 +315,7 @@ TODO: more discussion of version number -- actual numebr doesn't matter,
     we're just setting _something_ so the db complains, could use uids,
     also discuss similarity with eventsourcing version numbers.
 
-=== Testing for our data integrity rules
+=== Testing For Our Data Integrity Rules
 
 Now to actually make sure we can get the behaviour we want: if we have two
 concurrent attempts to do allocation against the same `Product`, one of them
@@ -414,7 +414,7 @@ def try_to_allocate(orderid, sku, exceptions):
 ====
 
 
-==== Enforcing concurrency rules by using database transaction isolation levels
+==== Enforcing Concurrency Rules By Using Database Transaction Isolation Levels
 
 To get the test to pass as it is, we can set the transaction isolation level
 on our session:
@@ -436,7 +436,7 @@ understanding https://www.postgresql.org/docs/9.6/transaction-iso.html[the
 documentation].
 
 
-==== SELECT FOR UPDATE can also help
+==== SELECT FOR UPDATE Can Also Help
 
 An alternative to using the `SERIALIZABLE` isolation level is to use
 https://www.postgresql.org/docs/9.6/explicit-locking.html[SELECT FOR UPDATE],

--- a/chapter_05_aggregate.asciidoc
+++ b/chapter_05_aggregate.asciidoc
@@ -94,9 +94,9 @@ purpose of data changes.
 ____
 
 Even if it weren't for the data integrity concerns, as a model gets more complex
-and grows more different _Entity_ and _Value Objects_, all of which start pointing
+and grows more different _entity_ and _value objects_, all of which start pointing
 to each other, it can be hard to keep track of who can modify what.  Especially
-when we have _Collections_ in the model like we do (our batches are a collection),
+when we have _collections_ in the model like we do (our batches are a collection),
 it's a good idea to nominate some entities to be the single entrypoint for
 modifying their related objects.  It makes the system conceptually simpler
 and easy to reason about if you nominate some objects to be in charge of consistency

--- a/chapter_06_events_and_message_bus.asciidoc
+++ b/chapter_06_events_and_message_bus.asciidoc
@@ -1,5 +1,5 @@
 [[chapter_06_events_and_message_bus]]
-== Events and the Message Bus
+== Events And The Message Bus
 
 So far we've spent a lot of time and energy on a simple problem that we could
 easily have solved with Django. You might be asking if the increased testability
@@ -18,9 +18,9 @@ problem by buying more stock, and all will be well.
 
 For a first version, our product owner says we can just send the alert by email.
 
-=== Avoiding making a mess.
+=== Avoiding Making A Mess.
 
-==== First, avoid making a mess of of our web controllers
+==== First, Avoid Making A Mess Of Of Our Web Controllers
 
 When we have a new requirement like this, that's not _really_ to do with the
 core domain, it's all too easy to start dumping these things into our web
@@ -91,7 +91,7 @@ NOTE: If you find yourself using `unittest.mock` to test external dependencies
     <<chapter_10_dependency_injection>>.
 
 
-==== ... And let's not make a mess of our model either
+==== ... And Let's Not Make A Mess Of Our Model Either
 
 Assuming we don't want to put this code into our web controllers, because
 we want them to be as thin as possible, we may look at putting it right at
@@ -119,7 +119,7 @@ But that's even worse!  We don't want our model to have any dependencies on
 infrastructure concerns like `email.send_mail`.
 
 
-==== Or the service layer!
+==== Or The Service Layer!
 
 In the service layer it's a little better, but it's still not lovely:
 
@@ -152,7 +152,7 @@ Catching an exception and re-raising it?  I mean, it could be worse, but it's
 definitely making us unhappy.
 
 
-===  Single Responsibility Principle
+=== Single Responsibility Principle
 
 Really this is a violation of the Single Responsibility Principle.  Our use
 case is allocation. Our endpoint, service function, and domain methods are all
@@ -175,7 +175,7 @@ want to apply the Dependency Inversion Principle to notifications, so that our
 service layer depends on an abstraction, in the same way as we avoid depending
 on the database by using a UnitOfWork.
 
-=== All aboard the Message Bus!
+=== All Aboard The Message Bus!
 
 The pattern we're going to introduce here is _Domain Events_ and the _Message Bus_.
 
@@ -184,7 +184,7 @@ recording "events"--facts about things that have happened. We'll use a Message
 Bus to respond to events, and invoke some new operation.
 
 
-==== The model records events
+==== The Model Records Events
 
 [[domain_event]]
 .The model records a domain event (src/allocation/model.py)
@@ -228,7 +228,7 @@ TODO: This ^^^ is true, but I think the real problem is that you shouldn't use
 exceptions for control-of-flow. It's like a classic design smell.
 
 
-==== Events are simple dataclasses
+==== Events Are Simple Dataclasses
 
 Events are part of our domain.  We could store them in _model.py_, but we
 may as well keep them in their own file.  (this might be a good time to
@@ -260,7 +260,7 @@ class OutOfStock(Event):  #<2>
 
 
 
-==== The message bus maps events to handlers
+==== The Message Bus Maps Events To Handlers
 
 A message bus essentially says: when I see this event, I should
 invoke the following handlers.  Here's a minimal implementation:
@@ -294,7 +294,7 @@ HANDLERS = {
 //TODO: maybe handle should just take one event?
 
 
-==== In a first cut, the service layer puts events on the message bus
+==== In A First Cut, The Service Layer Puts Events On The Message Bus
 
 And now we need something to catch events from the model and pass
 them to the message bus.  The service layer might be one place to do
@@ -336,7 +336,7 @@ but we can do better.
 TODO: discussion, service layer can/could raise events directly too.
 
 
-=== The Unit of Work can pass events to the Message Bus
+=== The Unit Of Work Can Pass Events To The Message Bus
 
 The UoW already has a `try/finally`, and it knows about all the aggregates
 currently in play because it provides access to the _Repository_.  So it's
@@ -503,7 +503,7 @@ class FakeUnitOfWork(unit_of_work.AbstractUnitOfWork):
 ====
 
 
-=== Unit Testing with a fake message bus
+=== Unit Testing With A Fake Message Bus
 
 TODO: discuss replacing @mock test with `FakeMessageBus`
 

--- a/chapter_06_events_and_message_bus.asciidoc
+++ b/chapter_06_events_and_message_bus.asciidoc
@@ -177,7 +177,7 @@ on the database by using a UnitOfWork.
 
 === All Aboard The Message Bus!
 
-The pattern we're going to introduce here is _Domain Events_ and the _Message Bus_.
+The pattern we're going to introduce here is _domain events_ and the _message bus_.
 
 First, rather than being concerned about emails, our model will be in charge of
 recording "events"--facts about things that have happened. We'll use a Message
@@ -256,7 +256,7 @@ class OutOfStock(Event):  #<2>
     class that can store common behaviour.  It's also useful for type
     hints in our message bus, as we'll see shortly.
 
-<2> `dataclasses` are great for Domain events too.
+<2> `dataclasses` are great for domain events too.
 
 
 
@@ -351,7 +351,7 @@ Once I read on to Example 10 everything cleared up immediately.
 https://github.com/python-leap/book/issues/35
 ////
 [[uow_with_messagebus]]
-.The UoW meets the Message Bus (src/allocation/unit_of_work.py)
+.The UoW meets the message bus (src/allocation/unit_of_work.py)
 ====
 [source,python]
 ----
@@ -516,7 +516,7 @@ TODO - wrap up for domain events chapter
 
 
 
-.Recap: Domain events and the Message Bus
+.Recap: Domain Events and the Message Bus
 *****************************************************************
 Events can help with SRP::
     bla

--- a/chapter_06_events_and_message_bus.asciidoc
+++ b/chapter_06_events_and_message_bus.asciidoc
@@ -159,11 +159,11 @@ case is allocation. Our endpoint, service function, and domain methods are all
 called `allocate`, not `allocate_and_send_mail_if_out_of_stock`.
 
 NOTE: Rule of thumb: if you can't describe what your class does without using
-    words like "then" or "and", you might be violating SRP.
+    words like "then" or "and," you might be violating SRP.
 
 This email sending thing is unwelcome *goop* messing up the nice clean flow
 of our system. What we'd like is to keep our domain model focused on the rule
-"You can't allocate more stuff than is actually available". 
+"You can't allocate more stuff than is actually available." 
 
 The domain model's job is to know that we're out of stock, but the
 responsibility of sending an alert belongs elsewhere. We should be able to turn
@@ -232,7 +232,7 @@ exceptions for control-of-flow. It's like a classic design smell.
 
 Events are part of our domain.  We could store them in _model.py_, but we
 may as well keep them in their own file.  (this might be a good time to
-consider refactoring out a directory called "domain", so we have _domain/model.py_
+consider refactoring out a directory called "domain," so we have _domain/model.py_
 and _domain/events.py_).
 
 [[events_dot_py]]

--- a/chapter_07_external_events.asciidoc
+++ b/chapter_07_external_events.asciidoc
@@ -1,5 +1,5 @@
 [[chapter_07_external_events]]
-== Event-Driven Architecture (using events to integrate microservices)
+== Event-driven Architecture (using Events To Integrate Microservices)
 ////
 TODO: 
 It would be cool to see the event flow in An internal event to express de-allocation as a diagram. Perhaps even an abstracted wall of sticky-notes?
@@ -17,7 +17,7 @@ to encompass the way that we handle incoming and outgoing messages from the
 system.
 
 
-=== Using a Redis pubsub channel for integration
+=== Using A Redis Pubsub Channel For Integration
 
 At MADE.com we use https://eventstore.org/[Eventstore] to convey messages
 between systems, but a lightweight solution based on Redis pubsub channels
@@ -79,7 +79,7 @@ essentially:
     look out for the expected reallocation.
 
 
-==== Redis is another thin adapter around our service layer
+==== Redis Is Another Thin Adapter Around Our Service Layer
 
 
 [[redis_pubsub_first_cut]]
@@ -122,7 +122,7 @@ def handle_change_batch_quantity(m):  #<2>
 So we'll need a new service called `change_batch_quantity`.
     
 
-=== Test-driving a new service at the service layer
+=== Test-driving A New Service At The Service Layer
 
 Following the lessons learned in <<chapter_03_service_layer>>,
 we can operate in "high gear," and write our unit tests at the highest
@@ -173,7 +173,7 @@ look like:
     and we expect to reallocated it to a new batch
 
 
-==== An internal event to express de-allocation
+==== An Internal Event To Express De-allocation
 
 A batch might have dozens of orders allocated to it. Similarly to the "out of
 stock" email, rather than doing deallocation and re-allocation in-line in the
@@ -341,7 +341,7 @@ TODO: should we have `Batch.change_purchased_quantity`?  But how to
 //TODO: we changed from Batch.deallocate to Batch.deallocate_one,
 // need do delete/amend some unit tests
 
-=== New handlers for allocated and deallocated events
+=== New Handlers For Allocated And Deallocated Events
 
 Here's what the events will look like:
 
@@ -414,7 +414,7 @@ def publish(channel, event):
 ====
 
 
-==== But handlers do now need a UoW
+==== But Handlers Do Now Need A Uow
 
 Our event handlers do now need a UoW.  We make a small modification
 to _unit_of_work.py_:
@@ -444,7 +444,7 @@ feel a little messy, however.
 
 
 
-=== Services can become event handlers
+=== Services Can Become Event Handlers
 
 Let's take a look at our services and message handlers side-by-side:
 
@@ -680,7 +680,7 @@ TODO: talk about the fact that we've implemented quite a complicated use case
     show a hacky version for comparison?
 
 
-=== What have we achieved?
+=== What Have We Achieved?
 
 * events are simple dataclasses that define the data structures for inputs,
   outputs, and internal messages within our system.  this is quite powerful
@@ -701,4 +701,3 @@ We've added bit of complexity to our architecture, but hopefully you can
 see how we've now made it very easy to plug in almost any new requirement
 from the business, whether it's a new use case, a new integration with
 one of our internal systems, or an integration with external systems.
-

--- a/chapter_07_external_events.asciidoc
+++ b/chapter_07_external_events.asciidoc
@@ -125,7 +125,7 @@ So we'll need a new service called `change_batch_quantity`.
 === Test-driving a new service at the service layer
 
 Following the lessons learned in <<chapter_03_service_layer>>,
-we can operate in "high gear", and write our unit tests at the highest
+we can operate in "high gear," and write our unit tests at the highest
 possible level of abstraction, the service layer.  Here's what they might
 look like:
 

--- a/chapter_08_commands.asciidoc
+++ b/chapter_08_commands.asciidoc
@@ -24,15 +24,15 @@ The differences between them, though, are important.
 
 Commands are sent by one actor to another specific actor. When I post a form
 to an API handler, I am sending a command. We name commands with imperative
-tense verb phrases like "allocate stock", or "delay shipment".
+tense verb phrases like "allocate stock," or "delay shipment."
 
 Commands capture _intent_. They express our wish for the system to do something.
 As a result, when they fail, the sender needs to receive error information.
 
 Events are broadcast by an actor to all interested listeners. When we pubish the
 `batch_quantity_changed` we don't know who's going to pick it up. We name events
-with past-tense verb phrases like "order allocated to stock", or
-"shipment delayed".
+with past-tense verb phrases like "order allocated to stock," or
+"shipment delayed."
 
 We often use events to spread the knowledge about successful commands.
 

--- a/chapter_08_commands.asciidoc
+++ b/chapter_08_commands.asciidoc
@@ -1,5 +1,5 @@
 [[chapter_08_commands]]
-== Commands and Command Handler
+== Commands And Command Handler
 
 In the previous chapter we talked about using event messages as a way of
 integrating systems. This starts to turn our application into a message
@@ -14,7 +14,7 @@ This might have felt counter-intuitive. After all, the batch _hasn't_ been
 created yet, that's why we called the API. We're going to fix that conceptual
 wart by introducing _commands_.
 
-== Commands and Events ==
+== Commands And Events ==
 
 Like events, commands are a type of message - instructions sent by one part of
 a system to another. Like events, we usually represent commands with dumb data

--- a/chapter_09_cqrs.asciidoc
+++ b/chapter_09_cqrs.asciidoc
@@ -1,12 +1,12 @@
 [[chapter_09_cqrs]]
-== Command-Query Responsibility Separation (CQRS)
+== Command-query Responsibility Separation (CQRS)
 
 NOTE: placeholder chapter, under construction
 
 Just, honestly, read this for now: https://io.made.com/commands-and-queries-handlers-and-views/
 
 
-=== Always Redirect after a POST?
+=== Always Redirect After A POST?
 
 The API returns information from the post request and that's bad, arguably.
 
@@ -79,7 +79,7 @@ def allocations_view_endpoint(orderid):
 ====
 
 
-=== Hold on to your lunch folks.
+=== Hold On To Your Lunch Folks.
 
 All right, a _views.py_, fair enough, we can keep read-only stuff in there,
 and it'll be a real views.py, not like Django's...
@@ -149,7 +149,7 @@ def test_allocations_view(sqlite_session_factory):
 ====
 
 
-=== Doubling down on the madness.
+=== Doubling Down On The Madness.
 
 that hardcoded sql query is pretty ugly right?  what if we made it nicer
 by keeping a totally separate, denormalised datastore for our view model?
@@ -260,7 +260,7 @@ def remove_allocation_from_read_model(
 ----
 ====
 
-=== But whyyyyyyy?
+=== But Whyyyyyyy?
 
 OK.  horrible, right? But also, kinda, surprisingly nice, considering? Our
 events and message bus give us a really nice place to do this sort of stuff,
@@ -276,4 +276,3 @@ So definitely don't do this. ever.  But, if you do need to, see how easy
 the event-driven model makes it?
 
 OK.  On that note, let's sally forth into our final chapter.
-

--- a/chapter_09_cqrs.asciidoc
+++ b/chapter_09_cqrs.asciidoc
@@ -1,5 +1,5 @@
 [[chapter_09_cqrs]]
-== Command-query Responsibility Separation (CQRS)
+== Command-Query Responsibility Separation (CQRS)
 
 NOTE: placeholder chapter, under construction
 

--- a/chapter_10_dependency_injection.asciidoc
+++ b/chapter_10_dependency_injection.asciidoc
@@ -142,7 +142,7 @@ choosing to monkeypatch `email.send_mail`, we are tied to doing `import email`,
 and if we ever want to do `from email import send_mail`, a trivial refactor,
 we'd have to change all our mocks.
 
-So it's a trade-off.  Yes declaring explicit dependencies is "unnecessary",
+So it's a trade-off.  Yes declaring explicit dependencies is "unnecessary,"
 strictly speaking, and using them would make our application code marginally
 more complex.  But in return, we'd get tests that are easier to write and
 manage.

--- a/chapter_10_dependency_injection.asciidoc
+++ b/chapter_10_dependency_injection.asciidoc
@@ -15,7 +15,7 @@ TIP: If you haven't already, it's worth reading <<appendix_abstractions>>
     before continuing with this chapter.
 
 
-=== Implicit vs explicit dependencies
+=== Implicit Vs Explicit Dependencies
 
 Our main handler functions declare an explicit dependency on the unit
 of work:
@@ -83,7 +83,7 @@ def test_rolls_back_uncommitted_work_by_default(sqlite_session_factory):
 
 
 
-=== Explicit dependencies are totally weird an java-ey tho
+=== Explicit Dependencies Are Totally Weird An Java-ey Tho
 
 If you're used to the way things normally happen in Python, you'll be thinking
 all this is a bit weird.  The standard way to do things is to declare our
@@ -176,7 +176,7 @@ Since we've now made the messagebus into the core of our application, it's the
 ideal place to manage these dependencies.
 
 
-=== MessageBus does DI
+=== Messagebus Does DI
 
 Here's one way to do it:
 
@@ -253,7 +253,7 @@ What else changes in the bus?
     the event we want to call:
 
 
-==== Depenency injection with minimal magic
+==== Depenency Injection With Minimal Magic
 
 Here's the core of our dependency injection approach then.  As you'll see
 there's not much to it:
@@ -285,7 +285,7 @@ functions and event handlers and other entrypoints, our dependencies would be
 all over the place.
 
 
-==== The messagebus takes ownership of adding new events to its queue
+==== The Messagebus Takes Ownership Of Adding New Events To Its Queue
 
 We've seen that the messagebus now has responsibility for collecting
 any new events raised by a handler, and adding them to the end of the queue.
@@ -316,7 +316,7 @@ class AbstractUnitOfWork(abc.ABC):
 ====
 
 
-=== Initialising DI in our app entrypoints
+=== Initialising DI In Our App Entrypoints
 
 In our flask app, we can just initialise the messagebus inline with
 the rest of our app config and setup, passing it in the actual
@@ -375,7 +375,7 @@ def handle_change_batch_quantity(m, bus: messagebus.MessageBus):
     (we'll look at fixing that in <<appendix_bootstrap>>.
 
 
-=== Initialising DI in our tests
+=== Initialising DI In Our Tests
 
 
 
@@ -407,4 +407,3 @@ class TestAddBatch:
 
 
 TODO: show option of custom fakes for email etc instead of mocks
-

--- a/part1.asciidoc
+++ b/part1.asciidoc
@@ -5,7 +5,7 @@
 
 [quote, Cyrille Martraire, DDD EU 2017]
 ____
-Most developers have never seen a Domain Model, only a Data Model.
+Most developers have never seen a domain model, only a data model.
 ____
 
 Most developers that we talk to about architecture have a nagging sense that

--- a/part1.asciidoc
+++ b/part1.asciidoc
@@ -1,6 +1,6 @@
 [[part1]]
 [part]
-== Part 1: Building an Architecture to Support Domain modelling.
+== Part 1: Building an Architecture to Support Domain Modelling
 
 
 [quote, Cyrille Martraire, DDD EU 2017]
@@ -16,27 +16,27 @@ but they've no idea how to fix it.
 
 We've found that many developers, when asked to design a new system, will
 immediately start to build a database schema, with the object model treated
-as an afterthought. This is where it all starts to go wrong. Instead, behaviour
-should come first, and drive our storage requirements.
+as an afterthought. This is where it all starts to go wrong. Instead, _behaviour
+should come first, and drive our storage requirements._
 
-After all, our customers don't care about the data model. They care about the
-what the system *does*, otherwise they'd just use a spreadsheet.
+After all, our customers don't care about the data model. They care about what
+the system *does*, otherwise they'd just use a spreadsheet.
 
 In this first part we'll look at how to build a rich object model through TDD
-(in <<chapter_01_domain_model,Chapter 1>>), and then how to keep that model
-decoupled from technical concerns. We'll see how to build persistence-agnostic
-code and how to create stable APIs around our domain so that we can refactor
-aggressively.
+(in <<chapter_01_domain_model,Chapter 1>>), and then we'll see how to keep that
+model decoupled from technical concerns. We'll see how to build
+persistence-agnostic code and how to create stable APIs around our domain so
+that we can refactor aggressively.
 
 To do that, we'll look at four key design patterns:
 
 * The <<chapter_02_repository,repository pattern>>, an abstraction over the
-  idea of persistent storage,
+  idea of persistent storage
 
 * A <<chapter_03_service_layer,service layer>> that clearly defines where our
-  use-cases begin and end,
+  use-cases begin and end
 
-* The <<chapter_04_uow,unit-of-work pattern>> to provide atomic operations,
+* The <<chapter_04_uow,unit-of-work pattern>> to provide atomic operations
 
 * And the <<chapter_05_aggregate,Aggregate pattern>> to enforce the integrity
   of our data.
@@ -46,11 +46,12 @@ but don't worry if none of it makes any sense yet!  We'll introduce each
 box one by one.
 
 [[part1_diag]]
+.A component diagram for our app at the end of Part 1
 image::diagrams/Chapter1Components.png[]
 
 //TODO: inline this diagram's source using asciidoc-diagram?
 
-Several of the appendices are further explorations of the content from Part 1.
+Several of the appendices are further explorations of the content from Part 1:
 
 * Each pattern usually involves an abstraction. <<appendix_abstractions>> takes a
   step back and uses a simple example to show how and why we choose abstractions

--- a/part2.asciidoc
+++ b/part2.asciidoc
@@ -46,6 +46,6 @@ Message bus::
 CQRS::
   Improve performance and scalability by separating reads and writes.
 
-Plus we'll introduce a Dependency Injection framework that uses type hints, just
+Plus we'll introduce a dependency injection framework that uses type hints, just
 to annoy Harry.
 //TODO: but we don't, currently.

--- a/preface.asciidoc
+++ b/preface.asciidoc
@@ -113,7 +113,7 @@ technology choices become minor implementation details.
 
 ==== Part 1: Dependency Inversion and Domain modelling
 
-Chapter 1: Domain modelling and DDD::
+Chapter 1: Domain Modelling and DDD::
     At some level, everyone has learned the lesson that complex business
     problems need to be reflected in code, in the form of a model of the domain.
     But why does it always seem to be so hard to do it, without getting tangled
@@ -122,7 +122,7 @@ Chapter 1: Domain modelling and DDD::
     show how to get started with a model that has no external dependencies, and
     fast unit tests.
 
-Chapter 2, 3 & 4: Repository, Service Layer and Unit of Work patterns::
+Chapter 2, 3 & 4: Repository, Service Layer and Unit of Work Patterns::
     In these 3 chapters we present 3 closely related and mutually reinforcing
     patterns that support our ambition to keep the model free of extraneous
     dependencies.  We build a layer of abstraction around persistent storage,
@@ -130,7 +130,7 @@ Chapter 2, 3 & 4: Repository, Service Layer and Unit of Work patterns::
     capture the primary use cases. We show how this layer makes it easy to
     build very thin entrypoints to our system, be it a Flask API or a CLI.
 
-Chapter 5: Aggregate pattern::
+Chapter 5: Aggregate Pattern::
     A brief return to the world of DDD, where we discuss how to choose the
     right _aggregate_, and how this choice relates to questions of data
     integrity
@@ -152,7 +152,7 @@ Chapter 9: CQRS::
     An example of _command-query responsibility segregation_, with and without
     events.
 
-Chapter 10 Dependency injection::
+Chapter 10 Dependency Injection::
     We tidy up our explicit and implicit dependencies, and implement a very
     simple dependency injection framework.
 

--- a/preface.asciidoc
+++ b/preface.asciidoc
@@ -84,24 +84,24 @@ first step for those who want to do further research  in this field.
 
 === Who Should Read This Book
 
-Here are a few things we're assuming about you, dear reader.
+Here are a few things we assume about you, dear reader.
 
-We're assuming you've been close to some reasonably complex Python applications.
+We assume you've been close to some reasonably complex Python applications.
 
-We're assuming you've seen some of the pain that comes with trying to manage
+We assume you've seen some of the pain that comes with trying to manage
 that complexity
 
-We're _not_ assuming that you already know anything about DDD, or any of the
+We do _not_ assume that you already know anything about DDD, or any of the
 classic application architecture patterns.
 
-Our explorations of architectural patterns will use an example app, building it
-up chapter by chapter.  We use Test-Driven Development (TDD) at work, so we
-tend to show listings of tests first, followed by implementation. If you're not
-used to working test-first, that may be a little strange at first, but we hope
-you'll soon get used to seeing code "being used," i.e. from the outside, before
-you see how it's built on the inside.
+We structure our explorations of architectural patterns around an example app,
+building it up chapter by chapter.  We use Test-Driven Development (TDD) at
+work, so we tend to show listings of tests first, followed by implementation.
+If you're not used to working test-first, that may be a little strange at
+first, but we hope you'll soon get used to seeing code "being used," i.e. from
+the outside, before you see how it's built on the inside.
 
-We will be using some specific Python (3) frameworks and technologies, like
+We use some specific Python (version 3) frameworks and technologies, like
 Flask, SQLAlchemy, and Pytest, as well as Docker and Redis.  If you're already
 familiar with them, that won't hurt, but we don't think it's required.  One of
 our main aims with this book is to build an architecture where specific
@@ -109,7 +109,7 @@ technology choices become minor implementation details.
 
 
 
-=== Overview
+=== A Brief Overview Of What You'll Learn
 
 ==== Part 1: Dependency Inversion and Domain modelling
 

--- a/preface.asciidoc
+++ b/preface.asciidoc
@@ -2,24 +2,24 @@
 [preface]
 == Preface
 
-=== Who are we and why are we writing this book?
+=== Who Are We And Why Are We Writing This Book?
 
-Hi, I'm Harry.  At the end of my last book,
+At the end of Harry's last book,
 http://www.obeythetestinggoat.com/pages/book.html[Test-Driven Development with Python],
-I found myself asking a bunch of questions about architecture -- what's the
+he found himself asking a bunch of questions about architecture -- what's the
 best way of structuring your application so that it's easy to test?  More
 specifically, so that your core business logic is covered by unit tests, and so
-that we minimise the number of integration and end-to-end tests we need?  I
+that we minimise the number of integration and end-to-end tests we need?  He
 made vague references to "Hexagonal Architecture" and "Ports and Adapters" and
-"Functional Core, Imperative Shell", but these weren't things I understood or
-had done in practice.
+"Functional Core, Imperative Shell", but if he was honest, he'd have to admit
+that these weren't things he really understood or had done in practice.
 
-And then I was lucky enough to run into Bob, who has the answers
-to all these questions.
+And then he was lucky enough to run into Bob, who has the answers to all these
+questions.  
 
-Hi, I'm Bob. I ended up a software architect because nobody else on my team was
-doing it. I turned out to be pretty bad at it, but I was lucky enough to run
-into Ian, who taught me new ways of writing and thinking about code.
+Bob ended up a software architect because nobody else on his team was
+doing it. He turned out to be pretty bad at it, but was lucky enough to run
+into Ian, who taught him new ways of writing and thinking about code.
 
 We both work for MADE.com - a European e-commerce company who sell furniture
 online - where we apply the techniques in this book to build distributed systems
@@ -55,17 +55,20 @@ of problems that the C# and Java world have been working on for years.
 Startups become real businesses, web apps and scripted automations are becoming
 (whisper it) enterprise software.
 
-In the Python world, we often quote the Zen of Python:  "there should be
-one--preferably on only one--obvious way to do it".  Unfortunately, as project
-complexity grows, the most obvious way of doing things isn't always the way
-that helps you manage complexity and evolving requirements.
+In the Python world, we often quote the Zen of Python:footnote:[`python -c "import this"`]
+"there should be one--and preferably only one--obvious way to do it."
+Unfortunately, as project size grows, the most obvious way of doing things
+isn't always the way that helps you manage complexity and evolving
+requirements.
 
 None of the techniques and patterns we're going to discuss in this book are
 new, but they are mostly new to the Python world.  And this book won't be
 a replacement for the classics in the field like 
-https://domainlanguage.com/ddd/[Evans' Domain-Driven Design]
+https://domainlanguage.com/ddd/[Eric Evans' _Domain-Driven Design_]
 or
-https://www.martinfowler.com/books/eaa.html[Fowler's Patterns of Enterprise Application Architecture] (both of which we'll often refer to and encourage you to go and read).
+https://www.martinfowler.com/books/eaa.html[Martin Fowler's _Patterns of
+Enterprise Application Architecture_] (both of which we often refer to and
+encourage you to go and read).
 
 But all the classic code examples in the literature do tend to be written in
 Java or pass:[C++]/#, and if you're a Python person and haven't used either of those
@@ -73,13 +76,13 @@ languages in a long time (or indeed ever), it can make them quite trying.
 There's a reason the latest edition of that other classic text, https://martinfowler.com/books/refactoring.html[Refactoring] is in JavaScript.
 
 So we hope this book will make for a lightweight introduction to some
-of the key architectural patterns that support Domain-Driven Design
+of the key architectural patterns that support domain-driven design
 (DDD) and event-driven microservices, that it will serve as a reference
 for implementing them in a Pythonic way, and that it will serve as a
 first step for those who want to do further research  in this field.
 
 
-=== Who might be reading this book
+=== Who Should Read This Book
 
 Here are a few things we're assuming about you, dear reader.
 
@@ -88,15 +91,15 @@ We're assuming you've been close to some reasonably complex Python applications.
 We're assuming you've seen some of the pain that comes with trying to manage
 that complexity
 
-We're not assuming you already know anything about DDD, or any of the
+We're _not_ assuming that you already know anything about DDD, or any of the
 classic application architecture patterns.
 
-We're going to be structuring our explorations of architectural patterns
-by using an example app, building it up chapter by chapter.  We use TDD at
-work, so we tend to show listings of tests first, followed by implementation.
-If you're not used to working test-first, that may be a little strange at
-first, but we hope you'll soon get used to seeing code "being used", i.e. from
-the outside, before you see how it's built on the inside.
+Our explorations of architectural patterns will use an example app, building it
+up chapter by chapter.  We use Test-Driven Development (TDD) at work, so we
+tend to show listings of tests first, followed by implementation. If you're not
+used to working test-first, that may be a little strange at first, but we hope
+you'll soon get used to seeing code "being used," i.e. from the outside, before
+you see how it's built on the inside.
 
 We will be using some specific Python (3) frameworks and technologies, like
 Flask, SQLAlchemy, and Pytest, as well as Docker and Redis.  If you're already

--- a/preface.asciidoc
+++ b/preface.asciidoc
@@ -11,7 +11,7 @@ best way of structuring your application so that it's easy to test?  More
 specifically, so that your core business logic is covered by unit tests, and so
 that we minimise the number of integration and end-to-end tests we need?  He
 made vague references to "Hexagonal Architecture" and "Ports and Adapters" and
-"Functional Core, Imperative Shell", but if he was honest, he'd have to admit
+"Functional Core, Imperative Shell," but if he was honest, he'd have to admit
 that these weren't things he really understood or had done in practice.
 
 And then he was lucky enough to run into Bob, who has the answers to all these
@@ -193,7 +193,7 @@ Here's three different ways you might code along with the book:
   work to get things working for the specifics of your project, but on the other
   hand you're likely to learn the most
 
-* For lower effort, in each chapter we'll outline an "exercise for the reader",
+* For lower effort, in each chapter we'll outline an "exercise for the reader,"
   and point you to a Github location where you can download some partially-finished
   code for the chapter with a few missing parts to write yourself.
 

--- a/preface.asciidoc
+++ b/preface.asciidoc
@@ -118,41 +118,43 @@ Chapter 1: Domain modelling and DDD::
     problems need to be reflected in code, in the form of a model of the domain.
     But why does it always seem to be so hard to do it, without getting tangled
     up with infrastructure concerns, with our web frameworks,or whatever else?
-    In this chapter we give a broad overview of Domain Modelling and DDD, and
+    In this chapter we give a broad overview of _domain modelling_ and DDD, and
     show how to get started with a model that has no external dependencies, and
     fast unit tests.
 
-Chapter 2-4: Repository, Service Layer and Unit of Work patterns::
+Chapter 2, 3 & 4: Repository, Service Layer and Unit of Work patterns::
     In these 3 chapters we present 3 closely related and mutually reinforcing
     patterns that support our ambition to keep the model free of extraneous
     dependencies.  We build a layer of abstraction around persistent storage,
-    and we build a service layer to define the entrypoints to our system, to
+    and we build a _service layer_ to define the entrypoints to our system, and
     capture the primary use cases. We show how this layer makes it easy to
     build very thin entrypoints to our system, be it a Flask API or a CLI.
 
 Chapter 5: Aggregate pattern::
     A brief return to the world of DDD, where we discuss how to choose the
-    right _Aggregate_, and how this choice relates to questions of data
+    right _aggregate_, and how this choice relates to questions of data
     integrity
+
 
 ==== Part 2: Event-Driven Architecture
 
-Chapters 6-8: Event-Driven Architecture::
+Chapters 6, 7 & 8: Event-Driven Architecture::
     We introduce three more mutually-reinforcing patterns, starting with 
-    the concept of _Domain Events_, a vehicle for capturing the idea that some
-    interactions with a system are triggers for others.  We use  a _Message
-    Bus_ to allow actions to trigger events, and call appropriate _Handlers_.
+    the concept of _domain events_, a vehicle for capturing the idea that some
+    interactions with a system are triggers for others.  We use  a _message
+    bus_ to allow actions to trigger events, and call appropriate _handlers_.
     We move on to discuss how events can be used as a pattern for integration
     between services, in a microservices architecture. Finally we add the
-    distinction between _Commands_ and events.  Our application is now
+    distinction between _commands_ and _events_.  Our application is now
     fundamentally a message-processing system.
 
 Chapter 9: CQRS::
-    An example of Command-Query Responsibility Segregation, with and without
+    An example of _command-query responsibility segregation_, with and without
     events.
 
 Chapter 10 Dependency injection::
-    tidy up the explicit vs implicit dependencies.  talk about DI vs mocks.
+    We tidy up our explicit and implicit dependencies, and implement a very
+    simple dependency injection framework.
 
 
 // TODO (DS): (General thoughts) There's nothing in the book about how to

--- a/prologue.asciidoc
+++ b/prologue.asciidoc
@@ -2,7 +2,7 @@
 [preface]
 == Introduction: Why Do Our Designs Go Wrong?
 
-What comes to mind when you hear the word "chaos"? Perhaps you think of a noisy
+What comes to mind when you hear the word "chaos?" Perhaps you think of a noisy
 stock exchange, or your kitchen in the morning - everything confused and
 jumbled. When you think of the word "order" perhaps you think of an empty room,
 serene and calm. For scientists, though, chaos is characterised by homogeneity,

--- a/prologue.asciidoc
+++ b/prologue.asciidoc
@@ -151,13 +151,13 @@ For example most people are familiar with the three layered architecture:
 
 TODO: replace with non-ascii diagram?
 
-This is perhaps the most common pattern for building business software. In this
-model we have user-interface components, which could be a web page, or an API,
-or a command line; these user-interface components communicate with a business
-logic layer that contains our business rules and our workflows; and finally we
-have a data layer that's responsible for storing and retrieving data. For the
-rest of this book, we're going to be systematically turning this model inside
-out by obeying one simple principle.
+Layered architecture is perhaps the most common pattern for building business
+software. In this model we have user-interface components, which could be a web
+page, or an API, or a command line; these user-interface components communicate
+with a business logic layer that contains our business rules and our workflows;
+and finally we have a data layer that's responsible for storing and retrieving
+data. For the rest of this book, we're going to be systematically turning this
+model inside out by obeying one simple principle.
 
 === The Dependency Inversion Principle
 
@@ -169,7 +169,8 @@ https://github.com/python-leap/book/issues/49
 ////
 
 You might be familiar with the dependency inversion principle already, because
-it's the D in the SOLID mnemonic. Formally, the DIP says:
+it's the D in the https://en.wikipedia.org/wiki/SOLID[SOLID] mnemonic.
+Formally, the DIP says:
 
 1.  High-level modules should not depend on low-level modules. Both should
     depend on abstractions.
@@ -179,15 +180,15 @@ it's the D in the SOLID mnemonic. Formally, the DIP says:
 
 But what does this mean? Let's take it bit by bit.
 
-"High level modules" are the code that your organisation really cares about.
+_High level modules_ are the code that your organisation really cares about.
 Perhaps you work for a pharmaceutical company, and your high-level modules deal
 with patients and trials. Perhaps you work for a bank, and your high level
 modules manage trades and exchanges. The high-level modules of a software
 system are the functions, classes, and packages that deal with our real world
 concepts.
 
-By contrast, "low-level modules" are the code that your organisation doesn't
-care about. It's unlikely that your HR department get excited about file
+By contrast, _low-level modules_ are the code that your organisation doesn't
+care about. It's unlikely that your HR department gets excited about file
 systems, or network sockets. It's not often that you can discuss SMTP, or HTTP,
 or AMQP with your finance team. For our non-technical stakeholders, these
 low-level concepts aren't interesting or relevant. All they care about is
@@ -195,17 +196,17 @@ whether the high-level concepts work correctly. If payroll runs on time, your
 business is unlikely to care whether that's a cron job or a transient function
 running on Kubernetes.
 
-We already know what abstractions are: they're simplified interfaces that
+And we've mentioned _abstractions_ already: they're simplified interfaces that
 encapsulate some role, in the way that our duckduckgo module encapsulated a
 search engine's API.
 
 So the first part of the DIP says that our business code shouldn't depend on
-technical details, instead they should both use abstractions.
+technical details; instead they should both use abstractions.
 
 The second part is even more mysterious. "Abstractions should not depend on
 details" seems clear enough, but "Details should depend on abstractions" is
 hard to imagine. How can we have an abstraction that doesn't depend on the
-details it's abstracting? We'll come to that shortly, but before we can turn
+details it's abstracting?  We'll come to that shortly, but before we can turn
 our three-layered architecture inside out, we need to talk more about that
 middle layer, the business logic.
 
@@ -213,9 +214,9 @@ One of the most common reasons that our designs go wrong is that business
 logic becomes spread out throughout the layers of our application, hard to
 identify, understand and change.
 
-Over the next few chapters, we'll discuss some application architecture patterns
-that allow us to keep our business layer, the domain model, free of dependencies
-and easy to maintain.
+The next few chapters discuss some application architecture patterns that allow
+us to keep our business layer, the domain model, free of dependencies and easy
+to maintain.
 
 //TODO: bob to review these last two paras.
 

--- a/prologue.asciidoc
+++ b/prologue.asciidoc
@@ -1,6 +1,6 @@
 [[part1_prologue]]
 [preface]
-== Prologue: Why do our designs go wrong?
+== Introduction: Why Do Our Designs Go Wrong?
 
 What comes to mind when you hear the word "chaos"? Perhaps you think of a noisy
 stock exchange, or your kitchen in the morning - everything confused and

--- a/prologue.asciidoc
+++ b/prologue.asciidoc
@@ -2,10 +2,10 @@
 [preface]
 == Introduction: Why Do Our Designs Go Wrong?
 
-What comes to mind when you hear the word "chaos?" Perhaps you think of a noisy
+What comes to mind when you hear the word _chaos?_ Perhaps you think of a noisy
 stock exchange, or your kitchen in the morning - everything confused and
-jumbled. When you think of the word "order" perhaps you think of an empty room,
-serene and calm. For scientists, though, chaos is characterised by homogeneity,
+jumbled. When you think of the word _order_ perhaps you think of an empty room,
+serene and calm. For scientists, though, chaos is characterized by homogeneity,
 and order by complexity.
 
 For example, a well-tended garden is a highly ordered system. Gardeners define
@@ -26,18 +26,18 @@ software systems are characterised by a sameness of function: API handlers that
 have domain knowledge, and send emails and perform logging; "business logic"
 classes that perform no calculations but do perform IO; and everything coupled
 to everything else so that changing any part of the system becomes fraught with
-danger. This is so common that software engineers have their own word for
+danger. This is so common that software engineers have their own term for
 chaos: The Big Ball of Mud anti-pattern.
 
-Big ball of mud is the natural state of software in the same way that wilderness
-bucket is the natural state of your garden. It takes energy and direction to
+Big ball of mud is the natural state of software in the same way that wildness
+is the natural state of your garden. It takes energy and direction to
 prevent the collapse. Fortunately, the techniques to avoid creating a big ball
 of mud aren't complex.
 
 === Encapsulation
 
-The term "encapsulation" covers two closely related ideas, simplifying
-behaviour and hiding data. When we encapsulate behaviour, we take a complex
+The term _encapsulation_ covers two closely related ideas: simplifying
+behaviour, and hiding data. When we encapsulate behaviour, we take a complex
 algorithm and place it behind a simpler abstraction. Consider the following two
 snippets of Python code, <<urllib_example>> and <<requests_example>>:
 
@@ -82,13 +82,14 @@ for r in results:
 ----
 ====
 
-Both of these code listings do the same thing: they submit form encoded values
-to a URL in order to use a search engine API, but the second is simpler to read
+Both of these code listings do the same thing: they submit form-encoded values
+to a URL in order to use a search engine API. But the second is simpler to read
 and understand because it operates at a higher level of abstraction. We can
 take this one step further still by identifying the role the code is playing
 and making it explicit.
 
 image::images/galaxybrainmeme.jpg["Galaxybrain meme",width="200px",float="right"]
+//TODO fix alignment and/or make 3 images.
 
 [[ddg_example]]
 .Do a search with the duckduckgo module

--- a/titlepage.html
+++ b/titlepage.html
@@ -1,15 +1,14 @@
 <section data-type="titlepage">
-<h1>Lightweight Enterprise Architecture Patterns with Python</h1>
+<h1>Enterprise Architecture Patterns with Python</h1>
 <!--(only include edition line if it's 2e or higher -->
 <!-- TODO DS
 About the title: I like the LEAP acronym, but I'm not sure it accurately describes the book.
-(i) I'm not sure what 'lightweight' means here - it's not really mentioned in the book, it feels to me like it's there just to make the acronym better.
 (ii) 'Patterns' - this suggests a patterns book, but I don't think this is one. They tend to be structured a little differently. This is more a book about one particular configuration of patterns.
 (iii) 'Enterprise' - I am in two minds about the use of this word so prominently. On the one hand I like it, because it identifies the gap that this book is addressing. On the other, it's possible it doesn't mean much to a lot of Python people - it's not a word I hear used much in that world.
 Having read the book, the key idea that would make me want to read it is that it's a guide to structuring large, complex applications using Python.  
 -->
 
-<p class="subtitle">How to Apply DDD, Ports and Adapters, and other Design Patterns in a Pythonic Way</p>
+<p class="subtitle">How to Apply DDD, Ports and Adapters, and Application Architecture Patterns in a Pythonic Way</p>
 
 <!--
 TODO DS Re. the subtitle. Lots of target readers may not have heard of DDD or ports and adapters. Maybe talking about complexity and scale would be better. 

--- a/uppercase-titles.py
+++ b/uppercase-titles.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+from pathlib import Path
+from chapters import CHAPTERS
+
+
+def fix_word(w):
+    if w.upper() == w:
+        return w
+    if w == 'CSVs':
+        return w
+    return w.capitalize()
+
+def fix_line(l):
+    if not l.startswith('=='):
+        return l
+    if l == '====':
+        return l
+    return ' '.join(fix_word(w) for w in l.split())
+
+
+for chapter in CHAPTERS:
+    path = Path(f'{chapter}.asciidoc')
+    contents = path.read_text()
+    fixed = '\n'.join(
+        fix_line(l) for l in contents.splitlines()
+    )
+    path.write_text(fixed)


### PR DESCRIPTION
CC = our editor.

- [x] Capitalize all main words in every heading.

- [x] Adjust the voice so that you always refer to the author as "we," and when referring to one or the other you use your first name, in third-person singular. Several examples in the PDF where I clarify this.

- [ ] When you refer to other books, don't link to any retail sites (we can't do that -- okay to link to authors' own websites). Just give the full title of the book, the author's full name, and the publisher and year in parentheses. Always use the book's title instead of something like "the DDD book."

- [ ] Use present tense instead of future when talking about the book. You'll see examples of what I mean.

- [x] You tend to use capital letters and or quotation marks when you want to emphasize or introduce something. Instead, use italics. Most computer terms, even if the acronym is capital letters, are actually just plan lowercase words. Domain-driven design, message bus, command query responsibility segregation, etc. If it's not a brand name, it's probably lowercased. But feel free to use italics for emphasis.

- [x] What you're calling the Prologue we call the Introduction, so we'd like you to rename that

- [ ] For almost all of your code, you've numbered them as Examples. That's fine, but if you do that remember you need to do two things every time: refer to it by number in the text (typically just before it appears) and include a caption. Mind you, you don't have to number all of them as Examples. You can just introduce any code you want to talk about with a colon, then a code block. Probably most O'Reilly books just introduce code like that, without numbering them and calling them Examples. Another confusion is some of them seem to be diagrams, not code. Those are Figures, not Examples. They need to be numbered in order (Figure 1-1, Figure 1-2, etc), referred to by name in the text, and captioned (with the caption appearing below).

- [x] Use of code font (monospaced font) for code terms (classes, methods, etc). You do this correctly in a few places, but mostly these are missing. I marked them for Ch 1 but please do this throughout the existing chapters.