### PR TITLE
pseudo-fix pseudo-code example syntax in bob's way

### DIFF
--- a/chapter_02B_abstractions.asciidoc
+++ b/chapter_02B_abstractions.asciidoc
@@ -386,24 +386,24 @@ modifiable:
 [source,python]
 [role="skip"]
 ----
-def synchronise_dirs(reader, apply_func, source_root, dest_root):  #<1>
-    source_hashes = reader(source_root)  #<2>
-    dest_hashes = reader(dest_root)  #<2>
+def synchronise_dirs(reader, apply_func, src_folder, dst_folder):  #<1>
+    source_hashes = reader(src_folder)  #<2>
+    dest_hashes = reader(dst_folder)  #<2>
 
     for sha, filename in src_hashes.items():
         if sha not in dst_hashes:
             sourcepath = src_folder / filename
             destpath = dst_folder / filename
-            apply_func('copy', sourcepath, destpath)  #<3>
+            apply_func('COPY', sourcepath, destpath)  #<3>
 
         elif dst_hashes[sha] != filename:
             olddestpath = dst_folder / dst_hashes[sha]
             newdestpath = dst_folder / filename
-            apply_func('move', olddestpath, newdestpath)  #<3>
+            apply_func('MOVE', olddestpath, newdestpath)  #<3>
 
     for sha, filename in dst_hashes.items():
         if sha not in src_hashes:
-            apply_func('delete', dst_folder / filename)  #<3>
+            apply_func('DELETE', dst_folder / filename)  #<3>
 ----
 ====
 
@@ -431,10 +431,10 @@ def test_when_a_file_exists_in_the_source_but_not_the_destination():
     dest = {}
     actions = []
 
-    reader = [source, dest]
+    reader = {"/source": source, "/dest": dest}
     synchronise_dirs(reader.pop, actions.append, "/source", "/dest")
 
-    assert actions = [("COPY", "/source/my-file", "/dest/my-file")]
+    assert actions == [("COPY", "/source/my-file", "/dest/my-file")]
 
 
 def test_when_a_file_has_been_renamed_in_the_source():
@@ -442,10 +442,10 @@ def test_when_a_file_has_been_renamed_in_the_source():
     dest = {"sha1": "original-file" }
     actions = []
 
-    reader = [source, dest]
+    reader = {"/source": source, "/dest": dest}
     synchronise_dirs(reader.pop, actions.append, "/source", "/dest")
 
-    assert actions = [("MOVE", "/dest/original-file", "/dest/renamed-file")]
+    assert actions == [("MOVE", "/dest/original-file", "/dest/renamed-file")]
 ----
 ====
 


### PR DESCRIPTION
Fixes some small syntax errors.  Also changes the use of `reader.pop` for what I think was intended originally.