### PR TITLE
Used EJ's DI version and reworked the text

### DIFF
--- a/chapter_02B_abstractions.asciidoc
+++ b/chapter_02B_abstractions.asciidoc
@@ -632,6 +632,52 @@ described this as "test damage".
 In either case, we can now work on fixing all the bugs in our implementation;
 enumerating tests for all the edge cases is now much easier.
 
+==== Why not just patch it out?
+
+At this point some of our readers will be scratching their heads and thinking
+"Why don't you just use `mock.patch`" and save yourself the effort?
+
+We avoid using mocks in this book, and in our production code, too. We're not
+going to enter into a Holy War, but our instinct is that mocking frameworks are
+a code smell.
+
+Instead, we like to clearly identify the responsiblities in our codebase, and to
+separate those responsibilties out into small, focused objects that are easy to
+replace with a test double.
+
+There's a few, closely related reasons for that:
+
+1. Patching out the dependency you're using makes it possible to unit test the
+code, but it does nothing to improve the design. Using mock.patch won't let your
+code work with a `--dry-run` flag, nor will it help you run against an ftp
+server. For that, you'll need to introduce abstractions.
+
+Designing for testability really means designing for extensibility. We trade off
+a little more complexity for a cleaner design that admits novel use-cases.
+
+2. Tests that use mocks _tend_ to be more coupled to the implementation details
+of the codebase. That's because mock tests verify the interactions between
+things: did I call `shutil.copy` with the right arguments? This coupling between
+code and test _tends_ to make tests more brittle in our experience.
+
+Martin Fowler wrote about this in his 2007 blog post 
+https://www.martinfowler.com/articles/mocksArentStubs.html[Mocks Aren't Stubs]
+
+3. Over-use of mocks leads to complicated test suites that fail to explain the
+code.
+
+We view TDD as a design practice first, and a testing practice second. The tests
+act as a record of our design choices, and serve to explain the system to us
+when we return to the code after a long absence.
+
+Tests that use too many mocks get overwhelmed with setup code that hides the
+story we care about.
+
+Steve Freeman has a great example of over-mocked tests in his talk
+https://www.youtube.com/watch?v=B48Exq57Zg8[Test Driven Development: That's Not What We Meant]
+
+
+
 
 .So Which Do We Use in this Book? FCIS or DI?
 ******************************************************************************

--- a/chapter_02B_abstractions.asciidoc
+++ b/chapter_02B_abstractions.asciidoc
@@ -632,7 +632,7 @@ described this as "test damage".
 In either case, we can now work on fixing all the bugs in our implementation;
 enumerating tests for all the edge cases is now much easier.
 
-==== Why not just patch it out?
+==== Why Not Just Patch It Out?
 
 At this point some of our readers will be scratching their heads and thinking
 "Why don't you just use `mock.patch`" and save yourself the effort?

--- a/chapter_02B_abstractions.asciidoc
+++ b/chapter_02B_abstractions.asciidoc
@@ -522,16 +522,16 @@ Our tests now act directly on the `determine_actions()` function:
 Because we've disentangled the logic of our program - the code for identifying
 changes - from the low-level details of IO, we can easily test the core of our code.
 
-==== Option 2: Dependency Injection
+==== Testing Edge-to-Edge with Fakes
 
-Let's call this the "Bob way," and it's about making dependencies explicit and
-modifiable:
+When we start writing a new system, we often focus on the core logic first,
+driving it with direct unit tests. At some point, though, we want to test bigger
+chunks of the system together.
 
-//
-// (ej) Referring back to the "coupling" diagram comment, the snippet below would look like:
-//
-// apply_func <- synchronize_dirs -> reader
-//
+We _could_ return to our end-to-end tests, but those are still as tricky to
+write and maintain as before. Instead, we often write tests that invoke a whole
+system together, but fake the IO, sort of _edge-to-edge_.
+
 
 [[di_version]]
 .Explicit dependencies (sync.py)
@@ -539,81 +539,16 @@ modifiable:
 [source,python]
 [role="skip"]
 ----
-def synchronise_dirs(reader, apply_func, src_folder, dst_folder):  #<1>
-    src_hashes = reader(src_folder)  #<2>
-    dst_hashes = reader(dst_folder)  #<2>
+def synchronise_dirs(reader, filesystem, source_root, dest_root): #<1>
 
-    for sha, filename in src_hashes.items():
-        if sha not in dst_hashes:
-            sourcepath = src_folder / filename
-            destpath = dst_folder / filename
-            apply_func('COPY', sourcepath, destpath)  #<3>
-
-        elif dst_hashes[sha] != filename:
-            olddestpath = dst_folder / dst_hashes[sha]
-            newdestpath = dst_folder / filename
-            apply_func('MOVE', olddestpath, newdestpath)  #<3>
-
-    for sha, filename in dst_hashes.items():
-        if sha not in src_hashes:
-            apply_func('DELETE', dst_folder / filename)  #<3>
-
-----
-====
-
-// TODO (DS): Why not just call reader `read_paths_and_hashes`, like in the
-// FCIS example?
-
-//NICE-TO-HAVE: test this listing
-
-<1> Our top-level function now exposes two new dependencies, a `reader` and an
-    `apply_func`
-
-<2> We invoke the `reader` to produce our dict-abstraction of the filesystems
-
-<3> And we invoke the `apply_func` using our action-abstraction for the actions
-    we want to apply.
-
-TIP: Notice that, although we're using dependency injection, there was no need
-    to define an abstract base class or any kind of explicit interface.  In the
-    book we often show ABCs because we hope they help to understand what the
-    abstraction is, but they're not necessary.  Python's dynamic nature means
-    we can always rely on duck typing.
-
-////
-TODO (DS)
-Really, the only difference between the DI approach shown here and the FCIS is
-that in DI, the orchestration logic can be tested against abstractions too (at
-the cost of some extra indirection).
-
-It feels to me that this DI approach is building on the FCIS, rather than
-demonstrating the 'pure' version of DI. In real life, it's nice to combine
-them, but perhaps it would be a clearer comparison if you showed a purer
-version of each.
-
-I also think you might need to address how the patterns you propose in this
-book relate to the alternative approaches. To me, it seems the core patterns
-are much more DI than FCIS. But you could also point out that the approaches
-can be combined - it's not either/or.
-////
-
-////
-TODO (e.j)
-Played around with this a bit, and I think introducing an explicit filesystem
-abstraction helps contrast the DI vs FCIS styles more strongly.
-
-It also make the duck-typing comment more relevant, and could be used to
-introduce the idea of roles and encapsulation.
-
-def ej_synchronise_dirs(reader, filesystem, source_root, dest_root):
-    source_hashes = reader(source_root)
+    source_hashes = reader(source_root) #<2>
     dest_hashes = reader(dest_root)
 
     for sha, filename in src_hashes.items():
         if sha not in dst_hashes:
             sourcepath = source_root / filename
             destpath = dest_root / filename
-            filesystem.copy(destpath, sourcepath)
+            filesystem.copy(destpath, sourcepath) #<3>
 
         elif dst_hashes[sha] != filename:
             olddestpath = dest_root / dst_hashes[sha]
@@ -623,6 +558,21 @@ def ej_synchronise_dirs(reader, filesystem, source_root, dest_root):
     for sha, filename in dst_hashes.items():
         if sha not in src_hashes:
             filesystem.del(dest_root/filename)
+----
+====
+
+<1> Our top-level function now exposes two new dependencies, a `reader` and a
+    `filesystem`
+
+<2> We invoke the `reader` to produce our files dict.
+
+<3> And we invoke the `filesystem` to apply the changes we detect.
+
+TIP: Notice that, although we're using dependency injection, there was no need
+    to define an abstract base class or any kind of explicit interface.  In the
+    book we often show ABCs because we hope they help to understand what the
+    abstraction is, but they're not necessary.  Python's dynamic nature means
+    we can always rely on duck typing.
 ////
 
 [[bob_tests]]
@@ -631,59 +581,53 @@ def ej_synchronise_dirs(reader, filesystem, source_root, dest_root):
 [source,python]
 [role="skip"]
 ----
+class FakeFileSystem(list): #<1>
+
+    def copy(self, src, dest): #<2>
+        self.append(('COPY', src, dest))
+
+    def move(self, src, dest):
+        self.append(('MOVE', src, dest))
+
+    def delete(self, dest):
+        self.append(('DELETE', src, dest))
+
+
 def test_when_a_file_exists_in_the_source_but_not_the_destination():
     source = {"sha1": "my-file" }
     dest = {}
-    actions = []
+    filesystem = FakeFileSystem()
 
     reader = {"/source": source, "/dest": dest}
-    synchronise_dirs(reader.pop, actions.append, "/source", "/dest")
+    synchronise_dirs(reader.pop, filesystem, "/source", "/dest")
 
-    assert actions == [("COPY", "/source/my-file", "/dest/my-file")]
+    assert filesystem == [("COPY", "/source/my-file", "/dest/my-file")]
 
 
 def test_when_a_file_has_been_renamed_in_the_source():
     source = {"sha1": "renamed-file" }
     dest = {"sha1": "original-file" }
-    actions = []
+    filesystem = FakeFileSystem()
 
     reader = {"/source": source, "/dest": dest}
-    synchronise_dirs(reader.pop, actions.append, "/source", "/dest")
+    synchronise_dirs(reader.pop, filesystem, "/source", "/dest")
 
-    assert actions == [("MOVE", "/dest/original-file", "/dest/renamed-file")]
+    assert filesystem == [("MOVE", "/dest/original-file", "/dest/renamed-file")]
 ----
 ====
 
-////
-TODO (ej)
-Modified this a bit to also introduce the filesystem abstraction.
+<1> Bob _loves_ using lists to build simple test doubles, even though his
+co-workers get mad. It means we can write tests like
+`assert 'foo' not in database`
 
-class FakeFilesystem(object):
-    def __init__(self, actions):
-        self._actions = actions or []
-
-    def copy(self, src, dest):
-        self._actions.append(('COPY', src, dest))
-
-    def move(self, src, dest):
-        self._actions.append(('MOVE', src, dest))
-
-    def delete(self, dest):
-        self._actions.append(('DELETE', src, dest))
-
-
-then
-
-
-     actions = [] # Using the shunt pattern here.
-
-////
-
+<2> Each method in our `FakeFileSystem` just appends something to the list so we
+can inspect it later. This is an example of a Spy Object.
 
 
 The advantage of this approach is that your tests act on the exact same function
-that's used by your production code.  The disadvantage is that DI usually demands
-a bit more work on the part of the reader to understand what's going on.
+that's used by your production code.  The disadvantage is that we have to make
+our stateful components explicit and we have to pass them around. DHH famously
+described this as "test damage".
 
 In either case, we can now work on fixing all the bugs in our implementation;
 enumerating tests for all the edge cases is now much easier.
@@ -693,9 +637,9 @@ enumerating tests for all the edge cases is now much easier.
 ******************************************************************************
 Both. Our domain model is entirely free of dependencies and side-effects,
 so that's our functional core.  The service layer that we build around it
-(in <<chapter_03_service_layer>>) is its imperative shell, but we actually
-use dependency injection to provide that imperative shell with things like
-access to the database, so we can still unit test it.
+(in <<chapter_03_service_layer>>) allows us to drive the system edge-to-edge
+and we use dependency injection to provide those services with stateful
+components, so we can still unit test them.
 
 See <<chapter_10_dependency_injection>> for more exploration of making our
 dependency injection more explicit and centralised.


### PR DESCRIPTION
We now introduce "pure domain model" and "edge-to-edge with DI" as achieving
different things, and use EJ's version of the DI code because it makes the
difference more obvious.

Need to update the code assuming people are happy with this

@xtaje and @seddonym is this any better? You both identified that the FCIS and DI impls were _basically the same_. This makes the difference clearer and pushes toward why you would prefer one or the other.

I do want to make a pretty diagram showing how the components interact in both versions, but I'll need to think about how to show that.